### PR TITLE
feat: Add support for case patterns with glob matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,7 @@ dependencies = [
 name = "rush"
 version = "0.1.0"
 dependencies = [
+ "glob",
  "libc",
  "nix",
  "rustyline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ rustyline = { version = "17.0.1", features = ["signal-hook"] }
 nix = { version = "0.30.1", features = ["signal"] }
 libc = "0.2"
 signal-hook = "0.3"
+glob = "0.3"

--- a/design.md
+++ b/design.md
@@ -10,17 +10,21 @@ Rush is a POSIX sh-compatible shell implemented in Rust. It supports interactive
 
 1. **Lexer**: Tokenizes input lines into tokens. Handles:
 
-   - Words (commands, args, with variable expansion $VAR)
-   - Operators: | (pipe), > (output redirect), < (input redirect), >> (append redirect)
-   - Quotes: "double" for expansion, 'single' for literal
-   - Escapes: \ for special chars
-   - Variables: $VAR, ${VAR}
+    - Words (commands, args, with variable expansion $VAR)
+    - Operators: | (pipe), > (output redirect), < (input redirect), >> (append redirect)
+    - Quotes: "double" for expansion, 'single' for literal
+    - Escapes: \ for special chars
+    - Variables: $VAR, ${VAR}
+    - Control flow: if, then, else, elif, fi, case, in, esac, ;;, ()
 
-2. **Parser**: Builds an Abstract Syntax Tree (AST) from tokens. Simple grammar:
+2. **Parser**: Builds an Abstract Syntax Tree (AST) from tokens. Grammar:
 
-   - Pipeline: Command | Command | ...
-   - Command: words + redirections (input/output files)
-   - No complex control flow initially (add if/while later if needed)
+    - Pipeline: Command | Command | ...
+    - Command: words + redirections (input/output files)
+    - Control Flow:
+        - If: if condition; then commands; [elif condition; then commands;]* [else commands;] fi
+        - Case: case word in pattern1|pattern2) commands ;; ... *) default ;; esac
+            - Patterns support glob matching (*, ?, [abc], etc.) using the glob crate
 
 3. **Executor**: Runs the AST:
 
@@ -55,6 +59,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust. It supports interactive
 - signal-hook crate (v0.3) for robust signal handling that works with rustyline
 - libc crate for low-level system interactions
 - nix crate (available for future advanced Unix I/O if needed)
+- glob crate (v0.3) for pattern matching in case statements
 
 ### Error Handling
 

--- a/examples/case_example.sh
+++ b/examples/case_example.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Example case statement with glob patterns
+
+echo "Testing case with glob patterns"
+echo
+
+# Test 1: File extension matching
+echo "Test 1: File type detection"
+case document.txt in
+    *.txt|*.md) echo "document.txt is a text file" ;;
+    *.jpg|*.png) echo "document.txt is an image" ;;
+    *) echo "document.txt is something else" ;;
+esac
+echo
+
+# Test 2: Single character wildcard
+echo "Test 2: Single character match"
+case file1 in
+    file?) echo "file1 matches file?" ;;
+    *) echo "file1 doesn't match" ;;
+esac
+echo
+
+# Test 3: Character class
+echo "Test 3: Character class [abc]"
+case b in
+    [abc]) echo "b is a, b, or c" ;;
+    *) echo "b is not a, b, or c" ;;
+esac
+echo
+
+# Test 4: Multiple patterns in one case
+echo "Test 4: Multiple patterns"
+case test.txt in
+    *.txt|*.sh|*.md) echo "test.txt is a script or text file" ;;
+    *.exe|*.bin) echo "test.txt is an executable" ;;
+    *) echo "test.txt is unknown" ;;
+esac
+echo
+
+# Test 5: Default case
+echo "Test 5: Default case"
+case random.stuff in
+    *.txt) echo "Text file" ;;
+    *.jpg) echo "Image" ;;
+    *) echo "random.stuff falls to default case" ;;
+esac

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -46,10 +46,18 @@ pub fn execute(ast: Ast) -> i32 {
             cases,
             default,
         } => {
-            // For now, simple implementation without glob matching
-            for (pattern, branch) in cases {
-                if word == pattern {
-                    return execute(branch);
+            for (patterns, branch) in cases {
+                for pattern in &patterns {
+                    if let Ok(glob_pattern) = glob::Pattern::new(pattern) {
+                        if glob_pattern.matches(&word) {
+                            return execute(branch);
+                        }
+                    } else {
+                        // If pattern is invalid, fall back to exact match
+                        if &word == pattern {
+                            return execute(branch);
+                        }
+                    }
                 }
             }
             if let Some(def) = default {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ pub enum Ast {
     },
     Case {
         word: String,
-        cases: Vec<(String, Ast)>,
+        cases: Vec<(Vec<String>, Ast)>,
         default: Option<Box<Ast>>,
     },
 }
@@ -92,6 +92,15 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                         }
                     }
                     _ => {}
+                }
+                i += 1;
+            }
+        } else if tokens[i] == Token::Case {
+            // For case statements, find the matching esac
+            while i < tokens.len() {
+                if tokens[i] == Token::Esac {
+                    i += 1; // Include the esac
+                    break;
                 }
                 i += 1;
             }
@@ -291,7 +300,6 @@ fn parse_if(tokens: &[Token]) -> Result<Ast, String> {
 }
 
 fn parse_case(tokens: &[Token]) -> Result<Ast, String> {
-    // Simple case: case word in pattern) commands ;; esac
     let mut i = 1; // Skip 'case'
 
     // Parse word
@@ -310,44 +318,84 @@ fn parse_case(tokens: &[Token]) -> Result<Ast, String> {
     }
     i += 1;
 
-    // Parse pattern
-    if i >= tokens.len() || !matches!(tokens[i], Token::Word(_)) {
-        return Err("Expected pattern after in".to_string());
-    }
-    let pattern = if let Token::Word(ref p) = tokens[i] {
-        p.clone()
-    } else {
-        unreachable!()
-    };
-    i += 1;
+    let mut cases = Vec::new();
+    let mut default = None;
 
-    if i >= tokens.len() || tokens[i] != Token::RightParen {
-        return Err("Expected ) after pattern".to_string());
-    }
-    i += 1;
+    loop {
+        // Skip newlines
+        while i < tokens.len() && tokens[i] == Token::Newline {
+            i += 1;
+        }
 
-    // Parse commands
-    let mut commands_tokens = Vec::new();
-    while i < tokens.len() && tokens[i] != Token::DoubleSemicolon && tokens[i] != Token::Esac {
-        commands_tokens.push(tokens[i].clone());
+        if i >= tokens.len() {
+            return Err("Unexpected end in case statement".to_string());
+        }
+
+        if tokens[i] == Token::Esac {
+            break;
+        }
+
+        // Parse patterns
+        let mut patterns = Vec::new();
+        while i < tokens.len() && tokens[i] != Token::RightParen {
+            if let Token::Word(ref p) = tokens[i] {
+                // Split pattern on |
+                for pat in p.split('|') {
+                    patterns.push(pat.to_string());
+                }
+            } else if tokens[i] == Token::Pipe {
+                // Skip | separator
+            } else if tokens[i] == Token::Newline {
+                // Skip newlines in patterns
+            } else {
+                return Err(format!("Expected pattern, found {:?}", tokens[i]));
+            }
+            i += 1;
+        }
+
+        if i >= tokens.len() || tokens[i] != Token::RightParen {
+            return Err("Expected ) after patterns".to_string());
+        }
         i += 1;
-    }
 
-    let commands_ast = parse_slice(&commands_tokens)?;
+        // Parse commands
+        let mut commands_tokens = Vec::new();
+        while i < tokens.len() && tokens[i] != Token::DoubleSemicolon && tokens[i] != Token::Esac {
+            commands_tokens.push(tokens[i].clone());
+            i += 1;
+        }
 
-    if i >= tokens.len() || tokens[i] != Token::DoubleSemicolon {
-        return Err("Expected ;; after commands".to_string());
-    }
-    i += 1;
+        let commands_ast = parse_slice(&commands_tokens)?;
 
-    if i >= tokens.len() || tokens[i] != Token::Esac {
-        return Err("Expected esac".to_string());
+        if i >= tokens.len() {
+            return Err("Unexpected end in case statement".to_string());
+        }
+
+        if tokens[i] == Token::DoubleSemicolon {
+            i += 1;
+            // Check if this is the default case (*)
+            if patterns.len() == 1 && patterns[0] == "*" {
+                default = Some(Box::new(commands_ast));
+            } else {
+                cases.push((patterns, commands_ast));
+            }
+        } else if tokens[i] == Token::Esac {
+            // Last case without ;;
+            if patterns.len() == 1 && patterns[0] == "*" {
+                default = Some(Box::new(commands_ast));
+            } else {
+                cases.push((patterns, commands_ast));
+            }
+            break;
+        } else {
+            return Err("Expected ;; or esac after commands".to_string());
+        }
     }
 
     Ok(Ast::Case {
         word,
-        cases: vec![(pattern, commands_ast)],
-        default: None,
+        cases,
+        default,
     })
 }
 


### PR DESCRIPTION
- Add glob crate dependency for pattern matching
- Update AST to support multiple patterns per case (pattern1|pattern2)
- Enhance parser to handle multiple case branches and pattern splitting
- Implement glob pattern matching in executor using glob::Pattern
- Update design.md with case statement documentation
- Add comprehensive example demonstrating glob patterns
- Support POSIX case syntax with glob wildcards (*, ?, [abc])

Tests: All existing tests pass + new glob pattern functionality verified