### PR TITLE
Fix builtin pipeline issue: cat input file is output file error

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -18,7 +18,11 @@ pub fn get_builtin_commands() -> Vec<String> {
     BUILTINS.iter().map(|s| s.to_string()).collect()
 }
 
-pub fn execute_builtin(cmd: &ShellCommand, shell_state: &mut ShellState) -> i32 {
+pub fn execute_builtin(
+    cmd: &ShellCommand,
+    shell_state: &mut ShellState,
+    output_override: Option<Box<dyn std::io::Write>>,
+) -> i32 {
     // Handle input redirection for built-ins that might need it
     let _input_content = if let Some(ref input_file) = cmd.input {
         match std::fs::read_to_string(input_file) {
@@ -33,7 +37,9 @@ pub fn execute_builtin(cmd: &ShellCommand, shell_state: &mut ShellState) -> i32 
     };
 
     // Prepare output destination
-    let mut output_writer: Box<dyn Write> = if let Some(ref output_file) = cmd.output {
+    let mut output_writer: Box<dyn Write> = if let Some(override_writer) = output_override {
+        override_writer
+    } else if let Some(ref output_file) = cmd.output {
         match File::create(output_file) {
             Ok(file) => Box::new(file),
             Err(e) => {
@@ -236,7 +242,7 @@ mod tests {
             append: None,
         };
         let mut shell_state = crate::state::ShellState::new();
-        let exit_code = execute_builtin(&cmd, &mut shell_state);
+        let exit_code = execute_builtin(&cmd, &mut shell_state, None);
         assert_eq!(exit_code, 0);
     }
 
@@ -249,7 +255,7 @@ mod tests {
             append: None,
         };
         let mut shell_state = crate::state::ShellState::new();
-        let exit_code = execute_builtin(&cmd, &mut shell_state);
+        let exit_code = execute_builtin(&cmd, &mut shell_state, None);
         assert_eq!(exit_code, 1);
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,8 +1,10 @@
 use std::fs::File;
+use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::process::{Command, Stdio};
 
 use super::parser::{Ast, ShellCommand};
 use super::state::ShellState;
+use nix::unistd;
 
 pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
     match ast {
@@ -80,7 +82,7 @@ fn execute_single_command(cmd: &ShellCommand, shell_state: &mut ShellState) -> i
     }
 
     if crate::builtins::is_builtin(&cmd.args[0]) {
-        crate::builtins::execute_builtin(cmd, shell_state)
+        crate::builtins::execute_builtin(cmd, shell_state, None)
     } else {
         let mut command = Command::new(&cmd.args[0]);
         command.args(&cmd.args[1..]);
@@ -158,12 +160,18 @@ fn execute_pipeline(commands: &[ShellCommand], shell_state: &mut ShellState) -> 
         if crate::builtins::is_builtin(&cmd.args[0]) {
             // Built-ins in pipelines are tricky - for now, execute them separately
             // This is not perfect but better than nothing
-            if let Some(_prev) = previous_stdout {
-                // We can't easily pipe to built-ins, so just execute
-                eprintln!("Warning: Built-in in pipeline may not work as expected");
+            if !is_last {
+                // Create a pipe to capture builtin output
+                let (reader_fd, writer_fd) = unistd::pipe().unwrap();
+                let reader = unsafe { std::fs::File::from_raw_fd(reader_fd.into_raw_fd()) };
+                let writer = unsafe { std::fs::File::from_raw_fd(writer_fd.into_raw_fd()) };
+                exit_code =
+                    crate::builtins::execute_builtin(cmd, shell_state, Some(Box::new(writer)));
+                previous_stdout = Some(Stdio::from(reader));
+            } else {
+                exit_code = crate::builtins::execute_builtin(cmd, shell_state, None);
+                previous_stdout = None;
             }
-            exit_code = crate::builtins::execute_builtin(cmd, shell_state);
-            previous_stdout = None;
         } else {
             let mut command = Command::new(&cmd.args[0]);
             command.args(&cmd.args[1..]);


### PR DESCRIPTION
- Root cause: Builtins in pipelines weren't properly piping output to next command
- Solution: Modified execute_builtin to accept optional output writer override
- For non-last builtins in pipeline, create pipe and capture output
- Updated all execute_builtin calls to include new parameter
- Tested with 'echo hello | cat' command - now works correctly