### PR TITLE
Fix alias parsing issue in .rushrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust. It provides both intera
   - `unalias`: Remove alias definitions
   - `test` / `[`: POSIX-compatible test builtin with string and file tests
   - `help`: Show available commands
+- **Configuration File**: Automatic sourcing of `~/.rushrc` on interactive shell startup
 - **Tab Completion**: Intelligent completion for commands, files, and directories.
   - **Command Completion**: Built-in commands and executables from PATH
   - **File/Directory Completion**: Files and directories with relative paths
@@ -387,6 +388,52 @@ fi
 
 The test builtin is fully integrated with Rush's control structures, enabling complex conditional logic in scripts while maintaining POSIX compatibility.
 
+### .rushrc Configuration File
+
+Rush automatically sources a configuration file `~/.rushrc` when starting in interactive mode, similar to bash's `.bashrc`. This allows you to customize your shell environment with:
+
+- **Environment Variables**: Set default variables and export them to child processes
+- **Aliases**: Define command shortcuts that persist across the session
+- **Shell Configuration**: Customize prompt, PATH, or other shell settings
+- **Initialization Commands**: Run setup commands on shell startup
+
+Example `~/.rushrc` file:
+
+```bash
+# Set environment variables
+export EDITOR=vim
+export PATH="$HOME/bin:$PATH"
+
+# Create useful aliases
+alias ll='ls -la'
+alias ..='cd ..'
+alias grep='grep --color=auto'
+
+# Set custom variables
+MY_PROJECTS="$HOME/projects"
+WORKSPACE="$HOME/workspace"
+
+# Display welcome message
+echo "Welcome to Rush shell!"
+echo "Type 'help' for available commands."
+```
+
+**Key Features:**
+
+- **Automatic Loading**: Sourced automatically when entering interactive mode
+- **Silent Failures**: Missing or invalid `.rushrc` files don't prevent shell startup
+- **Variable Persistence**: Variables and aliases set in `.rushrc` are available throughout the session
+- **Error Resilience**: Syntax errors in `.rushrc` are handled gracefully
+- **Standard Location**: Uses `~/.rushrc` following Unix conventions
+
+**Usage Notes:**
+
+- Only loaded in interactive mode (not in script or command-line modes)
+- Variables set in `.rushrc` are available to all subsequent commands
+- Use `export` to make variables available to child processes
+- Comments (lines starting with `#`) are ignored
+- Multi-line constructs (if/fi, case/esac) are supported
+
 ## Installation
 
 ### Prerequisites
@@ -420,6 +467,8 @@ Run the shell without arguments to enter interactive mode:
 ```
 
 You'll see a prompt showing the condensed current working directory followed by `$ ` (e.g., `/h/d/p/r/rush-sh $ `) where you can type commands. Type `exit` to quit.
+
+**Configuration**: Rush automatically sources `~/.rushrc` on startup if it exists, allowing you to set up aliases, environment variables, and other customizations.
 
 ### Script Mode
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -226,15 +226,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     current.clear();
                     in_single_quote = false;
                 } else if !in_double_quote {
-                    if !current.is_empty() {
-                        if let Some(keyword) = is_keyword(&current) {
-                            tokens.push(keyword);
-                        } else {
-                            let word = expand_variables_in_command(&current, shell_state);
-                            tokens.push(Token::Word(word));
-                        }
-                        current.clear();
-                    }
+                    // Start of single quote - don't push current word, just enter quote mode
                     in_single_quote = true;
                 }
                 chars.next();
@@ -505,6 +497,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
             tokens.push(Token::Word(word));
         }
     }
+
     Ok(tokens)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,9 @@ fn main() {
         use std::io::IsTerminal;
         if std::io::stdin().is_terminal() {
             // Interactive mode
+            // Source .rushrc file if it exists
+            source_rushrc(&mut shell_state);
+
             println!("Rush shell started. Type 'exit' to quit.");
             let mut rl = Editor::<completion::RushCompleter, FileHistory>::new().unwrap();
             rl.set_helper(Some(completion::RushCompleter::new()));
@@ -234,6 +237,74 @@ fn execute_command_string(command_string: &str, shell_state: &mut state::ShellSt
     }
 }
 
+fn source_rushrc(shell_state: &mut state::ShellState) {
+    // Get the home directory
+    if let Ok(home_dir) = env::var("HOME") {
+        let rushrc_path = format!("{}/.rushrc", home_dir);
+
+        // Try to read the .rushrc file
+        if let Ok(content) = fs::read_to_string(&rushrc_path) {
+            // Process the content similar to execute_script
+            let mut current_block = String::new();
+            let mut in_if_block = false;
+            let mut if_depth = 0;
+            let mut in_case_block = false;
+
+            for line in content.lines() {
+                // Skip shebang lines
+                if line.starts_with("#!") {
+                    continue;
+                }
+
+                // Skip pure comment lines
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed.starts_with("#") {
+                    continue;
+                }
+
+                // Check for multi-line construct keywords
+                if trimmed.starts_with("if ") || trimmed == "if" {
+                    in_if_block = true;
+                    if_depth += 1;
+                } else if trimmed.starts_with("case ") || trimmed == "case" {
+                    in_case_block = true;
+                }
+
+                // Add line to current block
+                if !current_block.is_empty() {
+                    current_block.push('\n');
+                }
+                current_block.push_str(line);
+
+                // Check for end of multi-line constructs
+                if in_if_block && trimmed == "fi" {
+                    if_depth -= 1;
+                    if if_depth == 0 {
+                        in_if_block = false;
+                        execute_line(&current_block, shell_state);
+                        current_block.clear();
+                    }
+                } else if in_case_block && trimmed == "esac" {
+                    in_case_block = false;
+                    execute_line(&current_block, shell_state);
+                    current_block.clear();
+                } else if !in_if_block && !in_case_block {
+                    // Execute single-line commands immediately
+                    execute_line(&current_block, shell_state);
+                    current_block.clear();
+                }
+            }
+
+            // Execute any remaining block
+            if !current_block.trim().is_empty() {
+                execute_line(&current_block, shell_state);
+            }
+        }
+        // If file doesn't exist or can't be read, silently continue
+    }
+    // If HOME is not set, silently continue
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,5 +392,36 @@ mod tests {
         assert_eq!(exit_code, 0);
         assert_eq!(std::env::current_dir().unwrap(), Path::new("/tmp"));
         std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_source_rushrc_functionality() {
+        // Create a temporary .rushrc file
+        let temp_dir = "/tmp/rush_test_home";
+        let rushrc_path = format!("{}/.rushrc", temp_dir);
+        let rushrc_content = "TEST_RUSHRC_VAR=test_value\nexport TEST_RUSHRC_VAR";
+
+        // Create temp directory and file
+        std::fs::create_dir_all(temp_dir).unwrap();
+        std::fs::write(&rushrc_path, rushrc_content).unwrap();
+
+        // Set HOME to temp directory
+        std::env::set_var("HOME", temp_dir);
+
+        // Test source_rushrc function
+        let mut shell_state = state::ShellState::new();
+        source_rushrc(&mut shell_state);
+
+        // Verify variable was set
+        assert_eq!(shell_state.get_var("TEST_RUSHRC_VAR"), Some("test_value".to_string()));
+
+        // Verify variable is exported
+        let child_env = shell_state.get_env_for_child();
+        assert_eq!(child_env.get("TEST_RUSHRC_VAR"), Some(&"test_value".to_string()));
+
+        // Clean up
+        std::fs::remove_file(&rushrc_path).unwrap();
+        std::fs::remove_dir(temp_dir).unwrap();
+        std::env::remove_var("HOME");
     }
 }


### PR DESCRIPTION
- Fix lexer single quote handling to properly parse aliases with spaces
- Update README.md with comprehensive .rushrc documentation
- Add source_rushrc function to main.rs for automatic .rushrc loading
- Add unit test for .rushrc functionality
- All existing tests pass (148/148)

The issue was that aliases like 'alias ll="ls -la"' were being parsed as multiple arguments instead of a single argument. Fixed by modifying the lexer's single quote handling to not split on quotes within words.