### PR TITLE
fix(env): disable colors in test to prevent ANSI codes breaking output assertion

### DIFF
--- a/src/builtins/builtin_env.rs
+++ b/src/builtins/builtin_env.rs
@@ -71,6 +71,7 @@ mod tests {
             append: None,
         };
         let mut shell_state = ShellState::new();
+        shell_state.colors_enabled = false;
         shell_state.set_exported_var("TEST_VAR", "test_value".to_string());
         let builtin = EnvBuiltin;
         let mut output = Vec::new();


### PR DESCRIPTION
The env builtin test failed under interactive terminals (e.g., fish in Alacritty) because ShellState::new() sets colors_enabled=true when stdout.is_terminal() returns true. This inserts ANSI escape sequences (e.g., \x1b[32mTEST_VAR\x1b[0m=test_value) in the writeln! output, breaking the contains("TEST_VAR=test_value") assertion as the string is no longer contiguous.

Fixed by explicitly setting shell_state.colors_enabled = false in the test to ensure clean, color-free output for reliable assertions. The builtin logic is unchanged and works correctly; this isolates the test from environment-specific terminal detection.

No other builtins affected, as confirmed by cargo test under fish.