### PR TITLE
feat: Add configurable condensed cwd display

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust. It provides both intera
     - Local variables: `local var=value`
     - Return statements: `return [value]`
     - Function introspection: `declare -f [function_name]`
-- **Built-in Commands** (18 total):
+- **Built-in Commands** (19 total):
   - `cd`: Change directory
   - `exit`: Exit the shell
   - `pwd`: Print working directory
@@ -93,6 +93,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust. It provides both intera
   - `test` / `[`: POSIX-compatible test builtin with string and file tests
   - `set_colors`: Enable/disable color output dynamically
   - `set_color_scheme`: Switch between color themes (default/dark/light)
+  - `set_condensed`: Enable/disable condensed cwd display in prompt
   - `declare`: Display function definitions and list function names
   - `help`: Show available commands
 - **Configuration File**: Automatic sourcing of `~/.rushrc` on interactive shell startup
@@ -458,21 +459,61 @@ This architecture enables command substitutions to behave identically to bash wh
 
 ### Condensed Current Working Directory in Prompt
 
-Rush now displays a condensed version of the current working directory in the interactive prompt:
+Rush displays a condensed version of the current working directory in the interactive prompt by default, but this behavior is now fully configurable:
 
 - **Condensed Path**: Each directory except the last is abbreviated to its first letter (preserving case)
 - **Full Last Directory**: The final directory in the path is shown in full
 - **Dynamic Updates**: The prompt updates automatically when changing directories
+- **Configurable Display**: Choose between condensed or full path display
 
-Example prompt displays:
+**Configuration Options:**
 
+```bash
+# Environment variable (set before starting shell)
+export RUSH_CONDENSED=true    # Enable condensed display (default)
+export RUSH_CONDENSED=false   # Enable full path display
+
+# Runtime control (in already running shell)
+set_condensed on              # Enable condensed display
+set_condensed off             # Enable full path display
+set_condensed status          # Show current setting
+```
+
+**Example Prompt Displays:**
+
+Condensed mode (default):
 ```bash
 /h/d/p/r/rush $
 /u/b/s/project $
 /h/u/Documents $
 ```
 
-This feature provides context about your current location while keeping the prompt concise.
+Full path mode:
+```bash
+/home/drew/projects/rush-sh $
+/usr/bin/src/project $
+/home/user/Documents $
+```
+
+**Usage Examples:**
+
+```bash
+# Start with condensed display (default behavior)
+rush-sh
+
+# Start with full path display
+RUSH_CONDENSED=false rush-sh
+
+# Toggle in running shell
+set_condensed off    # Switch to full paths
+set_condensed on     # Switch back to condensed
+set_condensed status # Check current setting
+
+# In ~/.rushrc for permanent preference
+echo 'export RUSH_CONDENSED=false' >> ~/.rushrc
+```
+
+This feature provides flexible control over prompt display while maintaining backward compatibility with the existing condensed format as the default.
 
 ### Arithmetic Expansion
 
@@ -1450,7 +1491,7 @@ Rush consists of the following components:
 
 ### Comprehensive Test Suite
 
-Rush includes an extensive test suite with **100+ test cases** ensuring reliability and correctness:
+Rush includes an extensive test suite with **275+ test cases** ensuring reliability and correctness:
 
 - **Unit Tests**: Individual component testing for lexer, parser, arithmetic engine, and parameter expansion
 - **Integration Tests**: End-to-end command execution, pipelines, redirections, and control structures

--- a/examples/condensed_cwd_demo.sh
+++ b/examples/condensed_cwd_demo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Demo script showing the condensed cwd feature
+
+echo "=== Rush Shell Condensed CWD Demo ==="
+echo
+
+echo "1. Default behavior (condensed enabled):"
+echo "   RUSH_CONDENSED=true rush-sh"
+echo "   # Shows: user@host:/t/d/n/d $"
+echo
+
+echo "2. Full path display:"
+echo "   RUSH_CONDENSED=false rush-sh"
+echo "   # Shows: user@host:/tmp/test/deep/nested/directory $"
+echo
+
+echo "3. Runtime toggle in existing shell:"
+echo "   set_condensed off    # Disable condensed display"
+echo "   set_condensed on     # Re-enable condensed display"
+echo "   set_condensed status # Show current setting"
+echo
+
+echo "4. Environment variable values:"
+echo "   RUSH_CONDENSED=true   # Enable condensed (default)"
+echo "   RUSH_CONDENSED=false  # Disable condensed"
+echo "   RUSH_CONDENSED=1      # Enable condensed"
+echo "   RUSH_CONDENSED=0      # Disable condensed"
+echo
+
+echo "=== Demo Complete ==="

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -37,6 +37,7 @@ mod builtin_pushd;
 mod builtin_pwd;
 mod builtin_set_color_scheme;
 mod builtin_set_colors;
+mod builtin_set_condensed;
 mod builtin_shift;
 mod builtin_source;
 mod builtin_test;
@@ -74,6 +75,7 @@ fn get_builtins() -> Vec<Box<dyn Builtin>> {
         Box::new(builtin_test::TestBuiltin),
         Box::new(builtin_set_colors::SetColorsBuiltin),
         Box::new(builtin_set_color_scheme::SetColorSchemeBuiltin),
+        Box::new(builtin_set_condensed::SetCondensedBuiltin),
         Box::new(builtin_shift::ShiftBuiltin),
         Box::new(builtin_declare::DeclareBuiltin),
     ]
@@ -218,6 +220,7 @@ mod tests {
         assert!(commands.contains(&".".to_string()));
         assert!(commands.contains(&"set_colors".to_string()));
         assert!(commands.contains(&"set_color_scheme".to_string()));
-        assert_eq!(commands.len(), 20);
+        assert!(commands.contains(&"set_condensed".to_string()));
+        assert_eq!(commands.len(), 21);
     }
 }

--- a/src/builtins/builtin_set_condensed.rs
+++ b/src/builtins/builtin_set_condensed.rs
@@ -1,0 +1,150 @@
+use std::io::Write;
+
+use crate::parser::ShellCommand;
+use crate::state::ShellState;
+
+pub struct SetCondensedBuiltin;
+
+impl super::Builtin for SetCondensedBuiltin {
+    fn name(&self) -> &'static str {
+        "set_condensed"
+    }
+
+    fn names(&self) -> Vec<&'static str> {
+        vec![self.name()]
+    }
+
+    fn description(&self) -> &'static str {
+        "Enable or disable condensed cwd display in prompt (set_condensed on|off|status)"
+    }
+
+    fn run(
+        &self,
+        cmd: &ShellCommand,
+        shell_state: &mut ShellState,
+        output_writer: &mut dyn Write,
+    ) -> i32 {
+        if cmd.args.len() < 2 {
+            if shell_state.condensed_cwd {
+                if shell_state.colors_enabled {
+                    writeln!(
+                        output_writer,
+                        "{}Condensed cwd display is enabled\x1b[0m",
+                        shell_state.color_scheme.success
+                    )
+                    .unwrap_or(());
+                } else {
+                    writeln!(output_writer, "Condensed cwd display is enabled").unwrap_or(());
+                }
+            } else {
+                writeln!(output_writer, "Condensed cwd display is disabled").unwrap_or(());
+            }
+            return 0;
+        }
+
+        match cmd.args[1].as_str() {
+            "on" | "enable" | "true" => {
+                shell_state.condensed_cwd = true;
+                if shell_state.colors_enabled {
+                    writeln!(
+                        output_writer,
+                        "{}Condensed cwd display enabled\x1b[0m",
+                        shell_state.color_scheme.success
+                    )
+                    .unwrap_or(());
+                } else {
+                    writeln!(output_writer, "Condensed cwd display enabled").unwrap_or(());
+                }
+            }
+            "off" | "disable" | "false" => {
+                shell_state.condensed_cwd = false;
+                writeln!(output_writer, "Condensed cwd display disabled").unwrap_or(());
+            }
+            "status" => {
+                if shell_state.condensed_cwd {
+                    if shell_state.colors_enabled {
+                        writeln!(
+                            output_writer,
+                            "{}Condensed cwd display is enabled\x1b[0m",
+                            shell_state.color_scheme.success
+                        )
+                        .unwrap_or(());
+                    } else {
+                        writeln!(output_writer, "Condensed cwd display is enabled").unwrap_or(());
+                    }
+                } else {
+                    writeln!(output_writer, "Condensed cwd display is disabled").unwrap_or(());
+                }
+            }
+            _ => {
+                if shell_state.colors_enabled {
+                    writeln!(
+                        output_writer,
+                        "{}Usage: set_condensed on|off|status\x1b[0m",
+                        shell_state.color_scheme.error
+                    )
+                    .unwrap_or(());
+                } else {
+                    writeln!(output_writer, "Usage: set_condensed on|off|status").unwrap_or(());
+                }
+                return 1;
+            }
+        }
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::Builtin;
+
+    #[test]
+    fn test_set_condensed_builtin_enable() {
+        let cmd = ShellCommand {
+            args: vec!["set_condensed".to_string(), "on".to_string()],
+            input: None,
+            output: None,
+            append: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = SetCondensedBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert!(shell_state.condensed_cwd);
+    }
+
+    #[test]
+    fn test_set_condensed_builtin_disable() {
+        let cmd = ShellCommand {
+            args: vec!["set_condensed".to_string(), "off".to_string()],
+            input: None,
+            output: None,
+            append: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = SetCondensedBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert!(!shell_state.condensed_cwd);
+    }
+
+    #[test]
+    fn test_set_condensed_builtin_status() {
+        let cmd = ShellCommand {
+            args: vec!["set_condensed".to_string(), "status".to_string()],
+            input: None,
+            output: None,
+            append: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = SetCondensedBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("enabled")); // Should show current status
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -67,6 +67,8 @@ pub struct ShellState {
     pub return_value: Option<i32>,
     /// Output capture buffer for command substitution
     pub capture_output: Option<Rc<RefCell<Vec<u8>>>>,
+    /// Whether to use condensed cwd display in prompt
+    pub condensed_cwd: bool,
 }
 
 impl ShellState {
@@ -88,6 +90,17 @@ impl ShellState {
             _ => !no_color && std::io::stdout().is_terminal(),
         };
 
+        // Check RUSH_CONDENSED environment variable for cwd display preference
+        let rush_condensed = std::env::var("RUSH_CONDENSED")
+            .map(|v| v.to_lowercase())
+            .unwrap_or_else(|_| "true".to_string());
+
+        let condensed_cwd = match rush_condensed.as_str() {
+            "1" | "true" | "on" | "enable" => true,
+            "0" | "false" | "off" | "disable" => false,
+            _ => true, // Default to condensed for backward compatibility
+        };
+
         Self {
             variables: HashMap::new(),
             exported: HashSet::new(),
@@ -106,6 +119,7 @@ impl ShellState {
             returning: false,
             return_value: None,
             capture_output: None,
+            condensed_cwd,
         }
     }
 
@@ -258,6 +272,14 @@ impl ShellState {
         }
     }
 
+    /// Get the full current working directory for the prompt
+    pub fn get_full_cwd(&self) -> String {
+        match std::env::current_dir() {
+            Ok(path) => path.to_string_lossy().to_string(),
+            Err(_) => "/?".to_string(), // fallback if can't get cwd
+        }
+    }
+
     /// Get the user@hostname string for the prompt
     pub fn get_user_hostname(&self) -> String {
         let user = env::var("USER").unwrap_or_else(|_| "user".to_string());
@@ -269,10 +291,15 @@ impl ShellState {
     pub fn get_prompt(&self) -> String {
         let user = env::var("USER").unwrap_or_else(|_| "user".to_string());
         let prompt_char = if user == "root" { "#" } else { "$" };
+        let cwd = if self.condensed_cwd {
+            self.get_condensed_cwd()
+        } else {
+            self.get_full_cwd()
+        };
         format!(
             "{}:{} {} ",
             self.get_user_hostname(),
-            self.get_condensed_cwd(),
+            cwd,
             prompt_char
         )
     }
@@ -626,5 +653,59 @@ mod tests {
         // Pop scope
         state.pop_local_scope();
         assert_eq!(state.get_var("test_var"), Some("global".to_string()));
+    }
+
+    #[test]
+    fn test_condensed_cwd_environment_variable() {
+        // Test default behavior (should be true for backward compatibility)
+        let state = ShellState::new();
+        assert!(state.condensed_cwd);
+
+        // Test explicit true
+        unsafe {
+            std::env::set_var("RUSH_CONDENSED", "true");
+        }
+        let state = ShellState::new();
+        assert!(state.condensed_cwd);
+
+        // Test explicit false
+        unsafe {
+            std::env::set_var("RUSH_CONDENSED", "false");
+        }
+        let state = ShellState::new();
+        assert!(!state.condensed_cwd);
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("RUSH_CONDENSED");
+        }
+    }
+
+    #[test]
+    fn test_get_full_cwd() {
+        let state = ShellState::new();
+        let full_cwd = state.get_full_cwd();
+        assert!(!full_cwd.is_empty());
+        // Should contain path separators (either / or \ depending on platform)
+        assert!(full_cwd.contains('/') || full_cwd.contains('\\'));
+    }
+
+    #[test]
+    fn test_prompt_with_condensed_setting() {
+        let mut state = ShellState::new();
+
+        // Test with condensed enabled (default)
+        assert!(state.condensed_cwd);
+        let prompt_condensed = state.get_prompt();
+        assert!(prompt_condensed.contains('@'));
+
+        // Test with condensed disabled
+        state.condensed_cwd = false;
+        let prompt_full = state.get_prompt();
+        assert!(prompt_full.contains('@'));
+
+        // Both should end with "$ " (or "# " for root)
+        assert!(prompt_condensed.ends_with("$ ") || prompt_condensed.ends_with("# "));
+        assert!(prompt_full.ends_with("$ ") || prompt_full.ends_with("# "));
     }
 }


### PR DESCRIPTION
- Add RUSH_CONDENSED environment variable support
- Implement set_condensed builtin for runtime control
- Add comprehensive tests and documentation
- Maintain backward compatibility with condensed display as default

Features:
- Environment variable RUSH_CONDENSED=true/false (default: true)
- Runtime control with set_condensed on/off/status commands
- Full path vs condensed path display options
- Integration with ~/.rushrc for permanent preferences