### PR TITLE
Fix: Allow .rushrc to override RUSH_CONDENSED setting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -434,6 +434,17 @@ fn source_rushrc(shell_state: &mut state::ShellState) {
             if !current_block.trim().is_empty() {
                 execute_line(&current_block, shell_state);
             }
+
+            // After sourcing .rushrc, check if RUSH_CONDENSED was set/exported
+            // This allows .rushrc to override the initial environment setting
+            if let Some(condensed_value) = shell_state.get_var("RUSH_CONDENSED") {
+                let condensed_lower = condensed_value.to_lowercase();
+                shell_state.condensed_cwd = match condensed_lower.as_str() {
+                    "1" | "true" | "on" | "enable" => true,
+                    "0" | "false" | "off" | "disable" => false,
+                    _ => shell_state.condensed_cwd, // Keep current value if invalid
+                };
+            }
         }
         // If file doesn't exist or can't be read, silently continue
     }
@@ -585,6 +596,61 @@ mod tests {
             child_env.get("TEST_RUSHRC_VAR"),
             Some(&"test_value".to_string())
         );
+
+        // Clean up
+        std::fs::remove_file(&rushrc_path).unwrap();
+        std::fs::remove_dir(&temp_dir).unwrap();
+        
+        // Restore original HOME value
+        unsafe {
+            if let Some(home) = original_home {
+                std::env::set_var("HOME", home);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    #[test]
+    fn test_source_rushrc_condensed_setting() {
+        // Test that .rushrc can override RUSH_CONDENSED setting
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir = format!("/tmp/rush_test_condensed_{}", timestamp);
+        let rushrc_path = format!("{}/.rushrc", temp_dir);
+
+        // Create temp directory and file
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        
+        // Test 1: .rushrc sets RUSH_CONDENSED=false
+        std::fs::write(&rushrc_path, "export RUSH_CONDENSED=false").unwrap();
+
+        // Save original HOME value
+        let original_home = std::env::var("HOME").ok();
+
+        // Set HOME to temp directory
+        unsafe {
+            std::env::set_var("HOME", &temp_dir);
+        }
+
+        // Create shell state and source .rushrc
+        let mut shell_state = state::ShellState::new();
+        source_rushrc(&mut shell_state);
+
+        // Verify condensed_cwd was set to false
+        assert!(!shell_state.condensed_cwd, "Expected condensed_cwd to be false after sourcing .rushrc with RUSH_CONDENSED=false");
+        
+        // Test 2: .rushrc sets RUSH_CONDENSED=true
+        std::fs::write(&rushrc_path, "export RUSH_CONDENSED=true").unwrap();
+        let mut shell_state2 = state::ShellState::new();
+        shell_state2.condensed_cwd = false; // Start with false
+        source_rushrc(&mut shell_state2);
+        
+        // Verify condensed_cwd was set to true
+        assert!(shell_state2.condensed_cwd, "Expected condensed_cwd to be true after sourcing .rushrc with RUSH_CONDENSED=true");
 
         // Clean up
         std::fs::remove_file(&rushrc_path).unwrap();


### PR DESCRIPTION
- Added check in source_rushrc() to re-evaluate RUSH_CONDENSED after sourcing
- This allows .rushrc to override the initial environment setting
- Added test case to verify the fix works correctly
- All 276 tests pass with no regressions

Fixes issue where 'export RUSH_CONDENSED=false' in .rushrc was ignored