### PR TITLE
Fix: Enable variable and command expansion in here-documents

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -196,6 +196,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_alias.rs
+++ b/src/builtins/builtin_alias.rs
@@ -73,6 +73,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -91,6 +92,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -109,6 +111,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -127,6 +130,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();

--- a/src/builtins/builtin_cd.rs
+++ b/src/builtins/builtin_cd.rs
@@ -60,6 +60,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -79,6 +80,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -97,6 +99,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_declare.rs
+++ b/src/builtins/builtin_declare.rs
@@ -294,6 +294,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -308,6 +309,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }]),
         );
@@ -332,6 +334,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -346,6 +349,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }]),
         );
@@ -372,6 +376,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -393,6 +398,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_dirs.rs
+++ b/src/builtins/builtin_dirs.rs
@@ -56,6 +56,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();

--- a/src/builtins/builtin_env.rs
+++ b/src/builtins/builtin_env.rs
@@ -70,6 +70,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_exit.rs
+++ b/src/builtins/builtin_exit.rs
@@ -53,6 +53,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_export.rs
+++ b/src/builtins/builtin_export.rs
@@ -62,6 +62,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -82,6 +83,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -104,6 +106,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_help.rs
+++ b/src/builtins/builtin_help.rs
@@ -85,6 +85,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_popd.rs
+++ b/src/builtins/builtin_popd.rs
@@ -75,6 +75,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let builtin = PopdBuiltin;

--- a/src/builtins/builtin_pushd.rs
+++ b/src/builtins/builtin_pushd.rs
@@ -104,6 +104,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();

--- a/src/builtins/builtin_pwd.rs
+++ b/src/builtins/builtin_pwd.rs
@@ -68,6 +68,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_set_color_scheme.rs
+++ b/src/builtins/builtin_set_color_scheme.rs
@@ -124,6 +124,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -143,6 +144,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_set_colors.rs
+++ b/src/builtins/builtin_set_colors.rs
@@ -98,6 +98,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -116,6 +117,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_set_condensed.rs
+++ b/src/builtins/builtin_set_condensed.rs
@@ -107,6 +107,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -125,6 +126,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -143,6 +145,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_shift.rs
+++ b/src/builtins/builtin_shift.rs
@@ -54,6 +54,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -87,6 +88,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -123,6 +125,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -142,6 +145,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_source.rs
+++ b/src/builtins/builtin_source.rs
@@ -93,6 +93,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();

--- a/src/builtins/builtin_test.rs
+++ b/src/builtins/builtin_test.rs
@@ -208,6 +208,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -225,6 +226,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -242,6 +244,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -259,6 +262,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -276,6 +280,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -293,6 +298,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -314,6 +320,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -338,6 +345,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -359,6 +367,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -379,6 +388,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -396,6 +406,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -417,6 +428,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -437,6 +449,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -454,6 +467,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -476,6 +490,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -498,6 +513,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -520,6 +536,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -542,6 +559,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -564,6 +582,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -586,6 +605,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -608,6 +628,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -630,6 +651,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -652,6 +674,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -674,6 +697,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -696,6 +720,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -718,6 +743,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -740,6 +766,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -762,6 +789,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -784,6 +812,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -806,6 +835,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -828,6 +858,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/builtins/builtin_trap.rs
+++ b/src/builtins/builtin_trap.rs
@@ -303,6 +303,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -329,6 +330,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -354,6 +356,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -380,6 +383,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -408,6 +412,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -436,6 +441,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -459,6 +465,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -482,6 +489,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -507,6 +515,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 

--- a/src/builtins/builtin_unalias.rs
+++ b/src/builtins/builtin_unalias.rs
@@ -75,6 +75,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let builtin = UnaliasBuiltin;
@@ -94,6 +95,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -111,6 +113,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -132,6 +135,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -155,6 +159,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let builtin = UnaliasBuiltin;
@@ -175,6 +180,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();
@@ -196,6 +202,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = crate::state::ShellState::new();

--- a/src/builtins/builtin_unset.rs
+++ b/src/builtins/builtin_unset.rs
@@ -47,6 +47,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -70,6 +71,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -69,6 +69,7 @@ fn execute_and_capture_output(ast: Ast, shell_state: &mut ShellState) -> Result<
                     output: None, // We're capturing output
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 };
 
@@ -942,6 +943,7 @@ fn execute_single_command(cmd: &ShellCommand, shell_state: &mut ShellState) -> i
             output: cmd.output.clone(),
             append: cmd.append.clone(),
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
 
@@ -1008,8 +1010,13 @@ fn execute_single_command(cmd: &ShellCommand, shell_state: &mut ShellState) -> i
         } else if let Some(ref delimiter) = cmd.here_doc_delimiter {
             // Handle here-document redirection
             let here_doc_content = collect_here_document_content(delimiter, shell_state);
-            // Expand variables and command substitutions in here-doc content
-            let expanded_content = expand_variables_in_string(&here_doc_content, shell_state);
+            // Expand variables and command substitutions ONLY if delimiter was not quoted
+            // Quoted delimiters (<<'EOF' or <<"EOF") disable expansion per POSIX
+            let expanded_content = if cmd.here_doc_quoted {
+                here_doc_content // No expansion for quoted delimiters
+            } else {
+                expand_variables_in_string(&here_doc_content, shell_state)
+            };
             let pipe_result = pipe();
             match pipe_result {
                 Ok((reader, mut writer)) => {
@@ -1196,6 +1203,7 @@ fn execute_pipeline(commands: &[ShellCommand], shell_state: &mut ShellState) -> 
                 output: cmd.output.clone(),
                 append: cmd.append.clone(),
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             };
             if !is_last {
@@ -1273,8 +1281,13 @@ fn execute_pipeline(commands: &[ShellCommand], shell_state: &mut ShellState) -> 
                 } else if let Some(ref delimiter) = cmd.here_doc_delimiter {
                     // Handle here-document redirection for first command in pipeline
                     let here_doc_content = collect_here_document_content(delimiter, shell_state);
-                    // Expand variables and command substitutions in here-doc content
-                    let expanded_content = expand_variables_in_string(&here_doc_content, shell_state);
+                    // Expand variables and command substitutions ONLY if delimiter was not quoted
+                    // Quoted delimiters (<<'EOF' or <<"EOF") disable expansion per POSIX
+                    let expanded_content = if cmd.here_doc_quoted {
+                        here_doc_content // No expansion for quoted delimiters
+                    } else {
+                        expand_variables_in_string(&here_doc_content, shell_state)
+                    };
                     let pipe_result = pipe();
                     match pipe_result {
                         Ok((reader, mut writer)) => {
@@ -1442,6 +1455,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -1458,6 +1472,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -1473,6 +1488,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         };
         let mut shell_state = ShellState::new();
@@ -1489,6 +1505,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             },
             ShellCommand {
@@ -1497,6 +1514,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             },
         ];
@@ -1521,6 +1539,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: None,
         }]);
         let mut shell_state = ShellState::new();
@@ -1538,6 +1557,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])),
         };
@@ -1561,6 +1581,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }]),
         );
@@ -1586,6 +1607,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }]),
         );
@@ -1624,6 +1646,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])),
         };
@@ -1664,6 +1687,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 }]),
             ])),
@@ -1717,6 +1741,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 }]),
             ])),
@@ -1736,6 +1761,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 }]),
             ])),
@@ -1773,6 +1799,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: None,
+            here_doc_quoted: false,
             here_string_content: Some("hello world".to_string()),
         };
 
@@ -1791,6 +1818,7 @@ mod tests {
             output: None,
             append: None,
             here_doc_delimiter: Some("EOF".to_string()),
+            here_doc_quoted: false,
             here_string_content: None,
         };
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1008,11 +1008,13 @@ fn execute_single_command(cmd: &ShellCommand, shell_state: &mut ShellState) -> i
         } else if let Some(ref delimiter) = cmd.here_doc_delimiter {
             // Handle here-document redirection
             let here_doc_content = collect_here_document_content(delimiter, shell_state);
+            // Expand variables and command substitutions in here-doc content
+            let expanded_content = expand_variables_in_string(&here_doc_content, shell_state);
             let pipe_result = pipe();
             match pipe_result {
                 Ok((reader, mut writer)) => {
                     use std::io::Write;
-                    if let Err(e) = writeln!(writer, "{}", here_doc_content) {
+                    if let Err(e) = writeln!(writer, "{}", expanded_content) {
                         if shell_state.colors_enabled {
                             eprintln!(
                                 "{}Error writing here-document content: {}\x1b[0m",
@@ -1271,11 +1273,13 @@ fn execute_pipeline(commands: &[ShellCommand], shell_state: &mut ShellState) -> 
                 } else if let Some(ref delimiter) = cmd.here_doc_delimiter {
                     // Handle here-document redirection for first command in pipeline
                     let here_doc_content = collect_here_document_content(delimiter, shell_state);
+                    // Expand variables and command substitutions in here-doc content
+                    let expanded_content = expand_variables_in_string(&here_doc_content, shell_state);
                     let pipe_result = pipe();
                     match pipe_result {
                         Ok((reader, mut writer)) => {
                             use std::io::Write;
-                            if let Err(e) = writeln!(writer, "{}", here_doc_content) {
+                            if let Err(e) = writeln!(writer, "{}", expanded_content) {
                                 if shell_state.colors_enabled {
                                     eprintln!(
                                         "{}Error writing here-document content: {}\x1b[0m",
@@ -1794,5 +1798,32 @@ mod tests {
         // For now, we'll just verify the command structure is parsed correctly
         assert_eq!(cmd.args, vec!["cat"]);
         assert_eq!(cmd.here_doc_delimiter, Some("EOF".to_string()));
+    }
+
+    #[test]
+    fn test_here_document_with_variable_expansion() {
+        // Test that variables are expanded in here-document content
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("PWD", "/test/path".to_string());
+        
+        // Simulate here-doc content with variable
+        let content = "Working dir: $PWD";
+        let expanded = expand_variables_in_string(content, &mut shell_state);
+        
+        assert_eq!(expanded, "Working dir: /test/path");
+    }
+
+    #[test]
+    fn test_here_document_with_command_substitution_builtin() {
+        // Test that builtin command substitutions work in here-document content
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("PWD", "/test/dir".to_string());
+        
+        // Simulate here-doc content with pwd builtin command substitution
+        let content = "Current directory: `pwd`";
+        let expanded = expand_variables_in_string(content, &mut shell_state);
+        
+        // The pwd builtin should be executed and expanded
+        assert!(expanded.contains("Current directory: "));
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,7 +11,7 @@ pub enum Token {
     RedirOut,
     RedirIn,
     RedirAppend,
-    RedirHereDoc(String),    // Here-document: <<DELIMITER
+    RedirHereDoc(String, bool), // Here-document: <<DELIMITER, bool=true if delimiter was quoted
     RedirHereString(String), // Here-string: <<<"content"
     If,
     Then,
@@ -701,6 +701,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         let mut delimiter = String::new();
                         let mut in_quote = false;
                         let mut quote_char = ' ';
+                        let mut was_quoted = false; // Track if any quotes were found
 
                         while let Some(&ch) = chars.peek() {
                             if ch == '\n' && !in_quote {
@@ -709,6 +710,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             if (ch == '"' || ch == '\'') && !in_quote {
                                 in_quote = true;
                                 quote_char = ch;
+                                was_quoted = true; // Mark that we found a quote
                                 chars.next(); // consume quote but don't add to delimiter
                             } else if in_quote && ch == quote_char {
                                 in_quote = false;
@@ -722,7 +724,8 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         }
 
                         if !delimiter.is_empty() {
-                            tokens.push(Token::RedirHereDoc(delimiter));
+                            // Pass both delimiter and whether it was quoted
+                            tokens.push(Token::RedirHereDoc(delimiter, was_quoted));
                         } else {
                             return Err(
                                 "Invalid here-document syntax: expected delimiter after <<"
@@ -1918,7 +1921,7 @@ mod tests {
             result,
             vec![
                 Token::Word("cat".to_string()),
-                Token::RedirHereDoc("EOF".to_string())
+                Token::RedirHereDoc("EOF".to_string(), false)
             ]
         );
     }
@@ -1944,7 +1947,7 @@ mod tests {
             result,
             vec![
                 Token::Word("command".to_string()),
-                Token::RedirHereDoc("EOF".to_string())
+                Token::RedirHereDoc("EOF".to_string(), true) // Quoted delimiter
             ]
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,9 +238,8 @@ fn main() {
                                 while i < lines.len() {
                                     let current_line = lines[i];
                                     
-                                    // Check if this line starts a heredoc
-                                    if current_line.contains("<<") && !current_line.contains("<<<") {
-                                        if let Some(delimiter) = extract_heredoc_delimiter(current_line) {
+                                    // Check if this line starts a heredoc using proper lexer detection
+                                    if let Some(delimiter) = line_contains_heredoc(current_line, &shell_state) {
                                             // Collect heredoc content from remaining lines
                                             let mut heredoc_content = String::new();
                                             i += 1;
@@ -276,7 +275,6 @@ fn main() {
                                             }
                                             continue;
                                         }
-                                    }
                                     
                                     // Execute normal line
                                     if !current_line.trim().is_empty() {
@@ -297,13 +295,11 @@ fn main() {
                                     break;
                                 }
                                 
-                                // Check if this line starts a here-document
-                                if line.contains("<<") && !line.contains("<<<") {
-                                    if let Some(delimiter) = extract_heredoc_delimiter(&line) {
-                                        // Start collecting heredoc content
-                                        shell_state.collecting_heredoc = Some((line.clone(), delimiter, String::new()));
-                                        continue;
-                                    }
+                                // Check if this line starts a here-document using proper lexer detection
+                                if let Some(delimiter) = line_contains_heredoc(&line, &shell_state) {
+                                    // Start collecting heredoc content
+                                    shell_state.collecting_heredoc = Some((line.clone(), delimiter, String::new()));
+                                    continue;
                                 }
                                 
                                 // Execute normal command
@@ -463,39 +459,22 @@ fn execute_line(line: &str, shell_state: &mut state::ShellState) {
         }
     }
 }
-/// Extract the here-document delimiter from a command line
-/// Returns the delimiter without quotes if found
-fn extract_heredoc_delimiter(line: &str) -> Option<String> {
-    // Find << but not <<<
-    if let Some(pos) = line.find("<<") {
-        // Make sure it's not <<<
-        if line.len() > pos + 2 && line.chars().nth(pos + 2) == Some('<') {
-            return None;
+/// Check if a line contains a heredoc redirection using proper lexer-based detection
+/// Returns the delimiter if found, None otherwise
+fn line_contains_heredoc(line: &str, shell_state: &state::ShellState) -> Option<String> {
+    // Use the lexer to properly parse the line
+    match lexer::lex(line, shell_state) {
+        Ok(tokens) => {
+            // Look for a RedirHereDoc token
+            for token in tokens {
+                if let lexer::Token::RedirHereDoc(delimiter, _quoted) = token {
+                    return Some(delimiter);
+                }
+            }
+            None
         }
-
-        // Extract everything after <<
-        let after_redir = &line[pos + 2..];
-        let trimmed = after_redir.trim_start();
-
-        // Extract the delimiter (up to whitespace or newline)
-        let delimiter: String = trimmed
-            .chars()
-            .take_while(|&c| c != ' ' && c != '\t' && c != '\n')
-            .collect();
-
-        if !delimiter.is_empty() {
-            // Strip quotes from delimiter if present
-            let unquoted = if (delimiter.starts_with('\'') && delimiter.ends_with('\''))
-                || (delimiter.starts_with('"') && delimiter.ends_with('"'))
-            {
-                delimiter[1..delimiter.len() - 1].to_string()
-            } else {
-                delimiter
-            };
-            return Some(unquoted);
-        }
+        Err(_) => None,
     }
-    None
 }
 
 fn execute_script(content: &str, shell_state: &mut state::ShellState) {
@@ -638,29 +617,26 @@ fn execute_script(content: &str, shell_state: &mut state::ShellState) {
             && !in_for_block
             && !in_while_block
         {
-            // Check if this line contains a here-document
-            if current_block.contains("<<") && !current_block.contains("<<<") {
-                // Try to extract the delimiter
-                if let Some(delimiter) = extract_heredoc_delimiter(&current_block) {
-                    // Collect here-document content from subsequent lines
-                    i += 1;
-                    let mut heredoc_content = String::new();
-                    while i < lines.len() {
-                        let content_line = lines[i];
-                        if content_line.trim() == delimiter.trim() {
-                            // Found the delimiter, stop collecting
-                            break;
-                        }
-                        if !heredoc_content.is_empty() {
-                            heredoc_content.push('\n');
-                        }
-                        heredoc_content.push_str(content_line);
-                        i += 1;
+            // Check if this line contains a here-document using proper lexer detection
+            if let Some(delimiter) = line_contains_heredoc(&current_block, shell_state) {
+                // Collect here-document content from subsequent lines
+                i += 1;
+                let mut heredoc_content = String::new();
+                while i < lines.len() {
+                    let content_line = lines[i];
+                    if content_line.trim() == delimiter.trim() {
+                        // Found the delimiter, stop collecting
+                        break;
                     }
-
-                    // Store the here-document content in shell state for the executor to use
-                    shell_state.pending_heredoc_content = Some(heredoc_content);
+                    if !heredoc_content.is_empty() {
+                        heredoc_content.push('\n');
+                    }
+                    heredoc_content.push_str(content_line);
+                    i += 1;
                 }
+
+                // Store the here-document content in shell state for the executor to use
+                shell_state.pending_heredoc_content = Some(heredoc_content);
             }
 
             // Execute single-line commands immediately

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,10 @@ fn main() {
             // Source .rushrc file if it exists
             source_rushrc(&mut shell_state);
 
-            let mut rl = Editor::<completion::RushCompleter, FileHistory>::new().unwrap();
+            let config = rustyline::Config::builder()
+                .bracketed_paste(true)  // Enable bracketed paste to handle multi-line pastes
+                .build();
+            let mut rl = Editor::<completion::RushCompleter, FileHistory>::with_config(config).unwrap();
             rl.set_helper(Some(completion::RushCompleter::new()));
 
             // Configure rustyline to handle signals gracefully
@@ -152,24 +155,161 @@ fn main() {
                     execute_exit_trap(&mut shell_state);
                     break;
                 }
-                let base_prompt = shell_state.get_prompt();
-                let prompt = if shell_state.colors_enabled {
-                    format!(
-                        "{}{}{}",
-                        shell_state.color_scheme.prompt, base_prompt, "\x1b[0m"
-                    )
+                
+                // Determine the prompt based on whether we're collecting a heredoc
+                let prompt_str = if shell_state.collecting_heredoc.is_some() {
+                    "> ".to_string()
                 } else {
-                    base_prompt
+                    let base_prompt = shell_state.get_prompt();
+                    if shell_state.colors_enabled {
+                        format!(
+                            "{}{}{}",
+                            shell_state.color_scheme.prompt, base_prompt, "\x1b[0m"
+                        )
+                    } else {
+                        base_prompt
+                    }
                 };
-                let readline = rl.readline(&prompt);
+                
+                let readline = rl.readline(&prompt_str);
                 match readline {
                     Ok(line) => {
-                        let _ = rl.add_history_entry(line.as_str());
-                        if line == "exit" {
-                            execute_exit_trap(&mut shell_state);
-                            break;
+                        // Check if we're currently collecting heredoc content
+                        if let Some((command_line, delimiter, mut content)) = shell_state.collecting_heredoc.take() {
+                            // We're collecting heredoc content
+                            // Check if this line (which might contain newlines from pasted input) contains the delimiter
+                            if line.contains('\n') {
+                                // Multi-line paste - split and process each line
+                                let lines: Vec<&str> = line.split('\n').collect();
+                                let mut found_delimiter = false;
+                                for (i, line_part) in lines.iter().enumerate() {
+                                    // Strip continuation prompt prefix if present ("> " from rustyline)
+                                    let cleaned_line = line_part.trim_start_matches("> ");
+                                    
+                                    if cleaned_line.trim() == delimiter.trim() {
+                                        // Found delimiter
+                                        found_delimiter = true;
+                                        // Execute with collected content
+                                        shell_state.pending_heredoc_content = Some(content.clone());
+                                        execute_line(&command_line, &mut shell_state);
+                                        
+                                        // Process any remaining lines after the delimiter as new commands
+                                        for remaining_line in lines.iter().skip(i + 1) {
+                                            if !remaining_line.trim().is_empty() {
+                                                execute_line(remaining_line, &mut shell_state);
+                                            }
+                                        }
+                                        break;
+                                    } else {
+                                        // Add to content (use cleaned line without prompt prefix)
+                                        if !content.is_empty() {
+                                            content.push('\n');
+                                        }
+                                        content.push_str(cleaned_line);
+                                    }
+                                }
+                                
+                                if !found_delimiter {
+                                    // No delimiter found, continue collecting
+                                    shell_state.collecting_heredoc = Some((command_line, delimiter, content));
+                                }
+                            } else {
+                                // Single line input
+                                if line.trim() == delimiter.trim() {
+                                    // Found the delimiter - execute the command
+                                    shell_state.pending_heredoc_content = Some(content);
+                                    execute_line(&command_line, &mut shell_state);
+                                } else {
+                                    // Add this line to heredoc content and continue collecting
+                                    if !content.is_empty() {
+                                        content.push('\n');
+                                    }
+                                    content.push_str(&line);
+                                    shell_state.collecting_heredoc = Some((command_line, delimiter, content));
+                                }
+                            }
+                        } else {
+                            // Normal line processing
+                            // Check if this is a multi-line paste with heredoc
+                            if line.contains('\n') && line.contains("<<") && !line.contains("<<<") {
+                                // Split the pasted content into lines
+                                let lines: Vec<&str> = line.split('\n').collect();
+                                let mut i = 0;
+                                while i < lines.len() {
+                                    let current_line = lines[i];
+                                    
+                                    // Check if this line starts a heredoc
+                                    if current_line.contains("<<") && !current_line.contains("<<<") {
+                                        if let Some(delimiter) = extract_heredoc_delimiter(current_line) {
+                                            // Collect heredoc content from remaining lines
+                                            let mut heredoc_content = String::new();
+                                            i += 1;
+                                            let mut found_delimiter = false;
+                                            
+                                            while i < lines.len() {
+                                                let line_to_check = lines[i].trim_start_matches("> ");
+                                                if line_to_check.trim() == delimiter.trim() {
+                                                    // Found delimiter
+                                                    found_delimiter = true;
+                                                    i += 1;
+                                                    break;
+                                                }
+                                                if !heredoc_content.is_empty() {
+                                                    heredoc_content.push('\n');
+                                                }
+                                                // Use cleaned line without prompt prefix
+                                                heredoc_content.push_str(line_to_check);
+                                                i += 1;
+                                            }
+                                            
+                                            if found_delimiter {
+                                                // Execute with collected content
+                                                shell_state.pending_heredoc_content = Some(heredoc_content);
+                                                execute_line(current_line, &mut shell_state);
+                                            } else {
+                                                // Delimiter not found in paste, start collecting interactively
+                                                shell_state.collecting_heredoc = Some((
+                                                    current_line.to_string(),
+                                                    delimiter,
+                                                    heredoc_content,
+                                                ));
+                                            }
+                                            continue;
+                                        }
+                                    }
+                                    
+                                    // Execute normal line
+                                    if !current_line.trim().is_empty() {
+                                        let _ = rl.add_history_entry(current_line);
+                                        if current_line == "exit" {
+                                            execute_exit_trap(&mut shell_state);
+                                            break;
+                                        }
+                                        execute_line(current_line, &mut shell_state);
+                                    }
+                                    i += 1;
+                                }
+                            } else {
+                                // Single line input
+                                let _ = rl.add_history_entry(line.as_str());
+                                if line == "exit" {
+                                    execute_exit_trap(&mut shell_state);
+                                    break;
+                                }
+                                
+                                // Check if this line starts a here-document
+                                if line.contains("<<") && !line.contains("<<<") {
+                                    if let Some(delimiter) = extract_heredoc_delimiter(&line) {
+                                        // Start collecting heredoc content
+                                        shell_state.collecting_heredoc = Some((line.clone(), delimiter, String::new()));
+                                        continue;
+                                    }
+                                }
+                                
+                                // Execute normal command
+                                execute_line(&line, &mut shell_state);
+                            }
                         }
-                        execute_line(&line, &mut shell_state);
 
                         // Process any signals that arrived during command execution
                         state::process_pending_signals(&mut shell_state);
@@ -183,26 +323,47 @@ fn main() {
                             println!("\nReceived SIGTERM, exiting gracefully.");
                             execute_exit_trap(&mut shell_state);
                             break;
-                        } else {
-                            // Check if this is a signal interruption (SIGINT)
-                            let err_str = format!("{}", err);
-                            if err_str.contains("Interrupted") {
-                                // SIGINT should just interrupt the current input line
-                                // Continue the loop to show a new prompt
-                                continue;
+                        }
+                        
+                        let err_str = format!("{}", err);
+                        
+                        // Check if this is an EOF while collecting heredoc
+                        if err_str.contains("EOF") && shell_state.collecting_heredoc.is_some() {
+                            // User pressed Ctrl-D while collecting heredoc
+                            // Execute the command with whatever content we have
+                            if let Some((command_line, _delimiter, content)) = shell_state.collecting_heredoc.take() {
+                                shell_state.pending_heredoc_content = Some(content);
+                                execute_line(&command_line, &mut shell_state);
                             }
-                            // For other errors, print and continue (don't break)
-                            if shell_state.colors_enabled {
-                                eprintln!(
-                                    "{}Readline error: {}\x1b[0m",
-                                    shell_state.color_scheme.error, err
-                                );
-                            } else {
-                                eprintln!("Readline error: {}", err);
-                            }
-                            // Continue instead of breaking to keep shell running
                             continue;
                         }
+                        
+                        // Check if this is a signal interruption (SIGINT)
+                        if err_str.contains("Interrupted") {
+                            // SIGINT should just interrupt the current input line
+                            // If we were collecting a heredoc, cancel it
+                            shell_state.collecting_heredoc = None;
+                            continue;
+                        }
+                        
+                        // Check if this is EOF in normal mode (exit the shell)
+                        if err_str.contains("EOF") {
+                            println!();
+                            execute_exit_trap(&mut shell_state);
+                            break;
+                        }
+                        
+                        // For other errors, print and continue (don't break)
+                        if shell_state.colors_enabled {
+                            eprintln!(
+                                "{}Readline error: {}\x1b[0m",
+                                shell_state.color_scheme.error, err
+                            );
+                        } else {
+                            eprintln!("Readline error: {}", err);
+                        }
+                        // Continue instead of breaking to keep shell running
+                        continue;
                     }
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -58,6 +58,7 @@ pub struct ShellCommand {
     pub output: Option<String>,
     pub append: Option<String>,
     pub here_doc_delimiter: Option<String>, // For here-document redirection
+    pub here_doc_quoted: bool,              // True if heredoc delimiter was quoted (disables expansion)
     pub here_string_content: Option<String>, // For here-string redirection
 }
 
@@ -80,6 +81,7 @@ fn create_empty_body_ast() -> Ast {
         output: None,
         append: None,
         here_doc_delimiter: None,
+            here_doc_quoted: false,
         here_string_content: None,
     }])
 }
@@ -648,8 +650,9 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                     current_cmd.append = Some(file.clone());
                 }
             }
-            Token::RedirHereDoc(delimiter) => {
+            Token::RedirHereDoc(delimiter, quoted) => {
                 current_cmd.here_doc_delimiter = Some(delimiter.clone());
+                current_cmd.here_doc_quoted = *quoted;
             }
             Token::RedirHereString(content) => {
                 current_cmd.here_string_content = Some(content.clone());
@@ -1322,6 +1325,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1342,6 +1346,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1365,6 +1370,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 },
                 ShellCommand {
@@ -1373,6 +1379,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 }
             ])
@@ -1395,6 +1402,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1417,6 +1425,7 @@ mod tests {
                 output: Some("output.txt".to_string()),
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1439,6 +1448,7 @@ mod tests {
                 output: None,
                 append: Some("output.txt".to_string()),
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1468,6 +1478,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 },
                 ShellCommand {
@@ -1476,6 +1487,7 @@ mod tests {
                     output: None,
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 },
                 ShellCommand {
@@ -1484,6 +1496,7 @@ mod tests {
                     output: Some("output.txt".to_string()),
                     append: None,
                     here_doc_delimiter: None,
+            here_doc_quoted: false,
                     here_string_content: None,
                 }
             ])
@@ -1519,6 +1532,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1542,6 +1556,7 @@ mod tests {
                 output: Some("file2.txt".to_string()),
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1780,7 +1795,7 @@ mod tests {
     fn test_parse_here_document_redirection() {
         let tokens = vec![
             Token::Word("cat".to_string()),
-            Token::RedirHereDoc("EOF".to_string()),
+            Token::RedirHereDoc("EOF".to_string(), false),
         ];
         let result = parse(tokens).unwrap();
         assert_eq!(
@@ -1791,6 +1806,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: Some("EOF".to_string()),
+            here_doc_quoted: false,
                 here_string_content: None,
             }])
         );
@@ -1811,6 +1827,7 @@ mod tests {
                 output: None,
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: Some("pattern".to_string()),
             }])
         );
@@ -1835,6 +1852,7 @@ mod tests {
                 output: Some("output.txt".to_string()),
                 append: None,
                 here_doc_delimiter: None,
+            here_doc_quoted: false,
                 here_string_content: Some("fallback".to_string()),
             }])
         );

--- a/src/state.rs
+++ b/src/state.rs
@@ -119,6 +119,8 @@ pub struct ShellState {
     pub pending_signals: bool,
     /// Pending here-document content from script execution
     pub pending_heredoc_content: Option<String>,
+    /// Interactive mode heredoc collection state
+    pub collecting_heredoc: Option<(String, String, String)>, // (command_line, delimiter, collected_content)
 }
 
 impl ShellState {
@@ -176,6 +178,7 @@ impl ShellState {
             exit_code: 0,
             pending_signals: false,
             pending_heredoc_content: None,
+            collecting_heredoc: None,
         }
     }
 


### PR DESCRIPTION
- Here-documents now properly expand variables (e.g., $PWD)
- Here-documents now support command substitutions (e.g., $(pwd), `pwd`)
- Builtins are now available within here-document content
- Added tests for here-doc variable and command substitution expansion
- Fixes issue where 'cat << EOF' with builtins would fail with 'Parse error: No commands found'
- Both execute_single_command() and execute_pipeline() now expand here-doc content

All 325 tests pass successfully.