### PR TITLE
Fix tilde expansion in quoted strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "rush-sh"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "clap",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [package]
 name = "rush-sh"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 description = "A POSIX sh-compatible shell written in Rust"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rush - A Unix shell written in Rust
 
-**Version 0.5.8** - A comprehensive POSIX sh-compatible shell implementation
+**Version 0.5.9** - A comprehensive POSIX sh-compatible shell implementation
 
-[![Repository Statistics](https://tokei.rs/b1/github/drewwalton19216801/rush-sh)](https://github.com/drewwalton19216801/rush-sh) [![dependency status](https://deps.rs/repo/github/drewwalton19216801/rush-sh/status.svg)](https://deps.rs/repo/github/drewwalton19216801/rush-sh)
+[![dependency status](https://deps.rs/repo/github/drewwalton19216801/rush-sh/status.svg)](https://deps.rs/repo/github/drewwalton19216801/rush-sh)
 
 ![Rush Logo](images/rush_logo.png)
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/docs/features.html
+++ b/docs/features.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">
@@ -100,7 +100,7 @@
                         <div class="hero-text">
                             <h1 class="hero-title">
                                 Rush Shell
-                                <span class="version-badge">v0.5.8</span>
+                                <span class="version-badge">v0.5.9</span>
                             </h1>
                             <p class="hero-subtitle">
                                 A comprehensive POSIX sh-compatible shell implementation written in Rust

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -53,7 +53,7 @@
 
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <span class="version">v0.5.8</span>
+                    <span class="version">v0.5.9</span>
                     <span class="status">~90% POSIX Compliant</span>
                 </div>
                 <div class="external-links">

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -854,7 +854,10 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 }
             }
             _ => {
-                if ch == '~' && current.is_empty() {
+                // Tilde expansion should only happen when:
+                // 1. The tilde is at the start of a word (current.is_empty())
+                // 2. We're not inside quotes (neither single nor double)
+                if ch == '~' && current.is_empty() && !in_single_quote && !in_double_quote {
                     if let Ok(home) = env::var("HOME") {
                         current.push_str(&home);
                     } else {
@@ -1994,6 +1997,64 @@ mod tests {
                 Token::RedirHereString("fallback".to_string()),
                 Token::RedirOut,
                 Token::Word("output.txt".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_unquoted() {
+        use std::env;
+        let shell_state = ShellState::new();
+        let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
+        let result = lex("echo ~", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word(home)
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_single_quoted() {
+        let shell_state = ShellState::new();
+        let result = lex("echo '~'", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_double_quoted() {
+        let shell_state = ShellState::new();
+        let result = lex("echo \"~\"", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_mixed_quotes() {
+        use std::env;
+        let shell_state = ShellState::new();
+        let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
+        let result = lex("echo ~ '~' \"~\"", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word(home),
+                Token::Word("~".to_string()),
+                Token::Word("~".to_string())
             ]
         );
     }


### PR DESCRIPTION
- Tilde expansion now only occurs when ~ is unquoted
- Added check for in_single_quote and in_double_quote flags
- Added 4 comprehensive test cases for tilde expansion behavior
- Fixes POSIX compliance issue where quoted tildes should not expand

Tests verify:
- Unquoted ~ expands to home directory
- Single-quoted '~' stays literal
- Double-quoted "~" stays literal
- Mixed usage works correctly