### PR TITLE
Fix tilde expansion logic

### DIFF
--- a/src/builtins/builtin_cd.rs
+++ b/src/builtins/builtin_cd.rs
@@ -23,7 +23,7 @@ impl super::Builtin for CdBuiltin {
     fn run(
         &self,
         cmd: &ShellCommand,
-        _shell_state: &mut ShellState,
+        shell_state: &mut ShellState,
         output_writer: &mut dyn Write,
     ) -> i32 {
         let dir = if cmd.args.len() > 1 {
@@ -36,10 +36,30 @@ impl super::Builtin for CdBuiltin {
         } else {
             dir
         };
+        
+        // Save current directory as OLDPWD before changing
+        if let Ok(current) = env::current_dir() {
+            let current_str = current.to_string_lossy().to_string();
+            shell_state.set_exported_var("OLDPWD", current_str.clone());
+            // Also update the environment variable
+            unsafe {
+                env::set_var("OLDPWD", current_str);
+            }
+        }
+        
         if let Err(e) = env::set_current_dir(Path::new(&path)) {
             let _ = writeln!(output_writer, "cd: {}: {}", path, e);
             1
         } else {
+            // Update PWD to the new directory
+            if let Ok(new_dir) = env::current_dir() {
+                let new_dir_str = new_dir.to_string_lossy().to_string();
+                shell_state.set_exported_var("PWD", new_dir_str.clone());
+                // Also update the environment variable so subsequent commands see the new PWD
+                unsafe {
+                    env::set_var("PWD", new_dir_str);
+                }
+            }
             0
         }
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -860,7 +860,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 if ch == '~' && current.is_empty() && !in_single_quote && !in_double_quote {
                     chars.next(); // consume ~
                     
-                    // Check for ~+ (PWD) or ~- (OLDPWD)
+                    // Check for ~+ (PWD), ~- (OLDPWD), or ~username
                     if let Some(&next_ch) = chars.peek() {
                         if next_ch == '+' {
                             // ~+ expands to $PWD
@@ -880,12 +880,48 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             } else {
                                 current.push_str("~-");
                             }
-                        } else {
-                            // Regular ~ expansion (HOME)
+                        } else if next_ch == '/' || next_ch == ' ' || next_ch == '\t' || next_ch == '\n' {
+                            // ~ followed by separator - expand to HOME
                             if let Ok(home) = env::var("HOME") {
                                 current.push_str(&home);
                             } else {
                                 current.push('~');
+                            }
+                        } else {
+                            // ~username expansion - collect username
+                            let mut username = String::new();
+                            while let Some(&ch) = chars.peek() {
+                                if ch == '/' || ch == ' ' || ch == '\t' || ch == '\n' {
+                                    break;
+                                }
+                                username.push(ch);
+                                chars.next();
+                            }
+                            
+                            if !username.is_empty() {
+                                // Try to get user's home directory
+                                // Special case for root user
+                                let user_home = if username == "root" {
+                                    "/root".to_string()
+                                } else {
+                                    format!("/home/{}", username)
+                                };
+                                
+                                // Check if the directory exists
+                                if std::path::Path::new(&user_home).exists() {
+                                    current.push_str(&user_home);
+                                } else {
+                                    // If directory doesn't exist, keep literal
+                                    current.push('~');
+                                    current.push_str(&username);
+                                }
+                            } else {
+                                // Empty username, expand to HOME
+                                if let Ok(home) = env::var("HOME") {
+                                    current.push_str(&home);
+                                } else {
+                                    current.push('~');
+                                }
                             }
                         }
                     } else {
@@ -2268,5 +2304,119 @@ mod tests {
                 Token::Word("prefix~+".to_string())
             ]
         );
+    }
+
+    #[test]
+    fn test_tilde_expansion_username() {
+        let shell_state = ShellState::new();
+        
+        // Test with root username (special case: /root instead of /home/root)
+        let result = lex("echo ~root", &shell_state).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Token::Word("echo".to_string()));
+        
+        // The expansion should either be /root or literal ~root (if /root doesn't exist)
+        if let Token::Word(path) = &result[1] {
+            assert!(path == "/root" || path == "~root");
+        } else {
+            panic!("Expected Word token");
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_username_with_path() {
+        let shell_state = ShellState::new();
+        
+        // Test ~username/path expansion
+        let result = lex("echo ~root/documents", &shell_state).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Token::Word("echo".to_string()));
+        
+        // Should expand to /root/documents or ~root/documents
+        if let Token::Word(path) = &result[1] {
+            assert!(path == "/root/documents" || path == "~root/documents");
+        } else {
+            panic!("Expected Word token");
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_nonexistent_user() {
+        let shell_state = ShellState::new();
+        
+        // Test with a username that definitely doesn't exist
+        let result = lex("echo ~nonexistentuser12345", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~nonexistentuser12345".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_username_in_quotes() {
+        let shell_state = ShellState::new();
+        
+        // Single quotes should prevent expansion
+        let result = lex("echo '~root'", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~root".to_string())
+            ]
+        );
+        
+        // Double quotes should also prevent expansion
+        let result = lex("echo \"~root\"", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~root".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_mixed_with_username() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let mut shell_state = ShellState::new();
+        let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
+        shell_state.set_var("PWD", "/current".to_string());
+        
+        // Test mixing different tilde expansions
+        let result = lex("echo ~ ~+ ~root", &shell_state).unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0], Token::Word("echo".to_string()));
+        assert_eq!(result[1], Token::Word(home));
+        assert_eq!(result[2], Token::Word("/current".to_string()));
+        
+        // The ~root expansion depends on whether /root exists
+        if let Token::Word(path) = &result[3] {
+            assert!(path == "/root" || path == "~root");
+        } else {
+            panic!("Expected Word token");
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_username_with_special_chars() {
+        let shell_state = ShellState::new();
+        
+        // Test that special characters terminate username collection
+        let result = lex("echo ~user@host", &shell_state).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Token::Word("echo".to_string()));
+        
+        // Should try to expand ~user and then append @host
+        if let Token::Word(path) = &result[1] {
+            // The path should contain @host at the end
+            assert!(path.contains("@host") || path == "~user@host");
+        } else {
+            panic!("Expected Word token");
+        }
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -858,15 +858,48 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 // 1. The tilde is at the start of a word (current.is_empty())
                 // 2. We're not inside quotes (neither single nor double)
                 if ch == '~' && current.is_empty() && !in_single_quote && !in_double_quote {
-                    if let Ok(home) = env::var("HOME") {
-                        current.push_str(&home);
+                    chars.next(); // consume ~
+                    
+                    // Check for ~+ (PWD) or ~- (OLDPWD)
+                    if let Some(&next_ch) = chars.peek() {
+                        if next_ch == '+' {
+                            // ~+ expands to $PWD
+                            chars.next(); // consume +
+                            if let Some(pwd) = shell_state.get_var("PWD").or_else(|| env::var("PWD").ok()) {
+                                current.push_str(&pwd);
+                            } else if let Ok(pwd) = env::current_dir() {
+                                current.push_str(&pwd.to_string_lossy());
+                            } else {
+                                current.push_str("~+");
+                            }
+                        } else if next_ch == '-' {
+                            // ~- expands to $OLDPWD
+                            chars.next(); // consume -
+                            if let Some(oldpwd) = shell_state.get_var("OLDPWD").or_else(|| env::var("OLDPWD").ok()) {
+                                current.push_str(&oldpwd);
+                            } else {
+                                current.push_str("~-");
+                            }
+                        } else {
+                            // Regular ~ expansion (HOME)
+                            if let Ok(home) = env::var("HOME") {
+                                current.push_str(&home);
+                            } else {
+                                current.push('~');
+                            }
+                        }
                     } else {
-                        current.push('~');
+                        // ~ at end of input, expand to HOME
+                        if let Ok(home) = env::var("HOME") {
+                            current.push_str(&home);
+                        } else {
+                            current.push('~');
+                        }
                     }
                 } else {
                     current.push(ch);
+                    chars.next();
                 }
-                chars.next();
             }
         }
     }
@@ -944,6 +977,10 @@ pub fn expand_aliases(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Mutex to serialize tests that modify environment variables
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Helper function to expand tokens like the executor does
     /// This simulates what happens at execution time
@@ -2003,7 +2040,7 @@ mod tests {
 
     #[test]
     fn test_tilde_expansion_unquoted() {
-        use std::env;
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
         let result = lex("echo ~", &shell_state).unwrap();
@@ -2044,7 +2081,7 @@ mod tests {
 
     #[test]
     fn test_tilde_expansion_mixed_quotes() {
-        use std::env;
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
         let result = lex("echo ~ '~' \"~\"", &shell_state).unwrap();
@@ -2055,6 +2092,180 @@ mod tests {
                 Token::Word(home),
                 Token::Word("~".to_string()),
                 Token::Word("~".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_pwd() {
+        let mut shell_state = ShellState::new();
+        
+        // Set PWD variable
+        let test_pwd = "/test/current/dir";
+        shell_state.set_var("PWD", test_pwd.to_string());
+        
+        let result = lex("echo ~+", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word(test_pwd.to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_oldpwd() {
+        let mut shell_state = ShellState::new();
+        
+        // Set OLDPWD variable
+        let test_oldpwd = "/test/old/dir";
+        shell_state.set_var("OLDPWD", test_oldpwd.to_string());
+        
+        let result = lex("echo ~-", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word(test_oldpwd.to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_pwd_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let shell_state = ShellState::new();
+        
+        // When PWD is not set, ~+ should expand to current directory
+        let result = lex("echo ~+", &shell_state).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Token::Word("echo".to_string()));
+        
+        // The second token should be a valid path (either from env::current_dir or literal ~+)
+        if let Token::Word(path) = &result[1] {
+            // Should either be a path or the literal ~+
+            assert!(path.starts_with('/') || path == "~+");
+        } else {
+            panic!("Expected Word token");
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_oldpwd_unset() {
+        // Lock to prevent parallel tests from interfering with environment variables
+        let _lock = ENV_LOCK.lock().unwrap();
+        
+        // Save and clear OLDPWD
+        let original_oldpwd = env::var("OLDPWD").ok();
+        unsafe {
+            env::remove_var("OLDPWD");
+        }
+        
+        let shell_state = ShellState::new();
+        
+        // When OLDPWD is not set, ~- should remain as literal
+        let result = lex("echo ~-", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~-".to_string())
+            ]
+        );
+        
+        // Restore OLDPWD
+        unsafe {
+            if let Some(oldpwd) = original_oldpwd {
+                env::set_var("OLDPWD", oldpwd);
+            }
+        }
+    }
+
+    #[test]
+    fn test_tilde_expansion_pwd_in_quotes() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("PWD", "/test/dir".to_string());
+        
+        // Single quotes should prevent expansion
+        let result = lex("echo '~+'", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~+".to_string())
+            ]
+        );
+        
+        // Double quotes should also prevent expansion
+        let result = lex("echo \"~+\"", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~+".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_oldpwd_in_quotes() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("OLDPWD", "/test/old".to_string());
+        
+        // Single quotes should prevent expansion
+        let result = lex("echo '~-'", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~-".to_string())
+            ]
+        );
+        
+        // Double quotes should also prevent expansion
+        let result = lex("echo \"~-\"", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("~-".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_mixed() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let mut shell_state = ShellState::new();
+        let home = env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
+        shell_state.set_var("PWD", "/current".to_string());
+        shell_state.set_var("OLDPWD", "/previous".to_string());
+        
+        let result = lex("echo ~ ~+ ~-", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word(home),
+                Token::Word("/current".to_string()),
+                Token::Word("/previous".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_tilde_expansion_not_at_start() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("PWD", "/test".to_string());
+        
+        // Tilde should not expand when not at start of word
+        let result = lex("echo prefix~+", &shell_state).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Token::Word("echo".to_string()),
+                Token::Word("prefix~+".to_string())
             ]
         );
     }


### PR DESCRIPTION
Implements comprehensive tilde expansion functionality for POSIX compliance.

**Features Added**
- ~+ expansion: Expands to current working directory ($PWD)
- ~- expansion: Expands to previous working directory ($OLDPWD)
- ~username expansion: Expands to user home directories
  - Special case: ~root → /root
  - Other users: ~username → /home/username
  - Falls back to literal if directory doesn't exist

**Changes**
- Enhanced lexer tilde expansion logic in src/lexer.rs
- Updated cd builtin to properly maintain PWD/OLDPWD variables
- Added 14 comprehensive tests covering all expansion scenarios
- Proper quote handling (no expansion inside quotes)
- Thread-safe test implementation with ENV_LOCK

Fixes #62 