### PR TITLE
Fix: Reset was_quoted flag after empty quoted strings

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -378,6 +378,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 if just_closed_quote && current.is_empty() {
                     tokens.push(Token::Word("".to_string()));
                     just_closed_quote = false;
+                    was_quoted = false; // Reset after pushing empty quoted string
                 } else {
                     flush_current_token(&mut current, &mut tokens, was_quoted);
                     was_quoted = false; // Reset after flushing
@@ -389,6 +390,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 if just_closed_quote && current.is_empty() {
                     tokens.push(Token::Word("".to_string()));
                     just_closed_quote = false;
+                    was_quoted = false; // Reset after pushing empty quoted string
                 } else {
                     flush_current_token(&mut current, &mut tokens, was_quoted);
                     was_quoted = false; // Reset after flushing
@@ -1118,6 +1120,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 if just_closed_quote && current.is_empty() {
                     tokens.push(Token::Word("".to_string()));
                     just_closed_quote = false;
+                    was_quoted = false; // Reset after pushing empty quoted string
                 } else {
                     flush_current_token(&mut current, &mut tokens, false);
                 }


### PR DESCRIPTION
When processing empty quoted strings (e.g., echo ""), the lexer was not resetting the was_quoted flag. This caused subsequent keywords like 'fi' to be incorrectly lexed as Word("fi") instead of Token::Fi, leading to 'Expected fi' parse errors.

The fix adds was_quoted = false after handling empty quoted strings in three locations:
- After space/tab (line 380)
- After newline (line 392)
- After semicolon (line 1120)

This ensures keywords following empty strings are properly recognized.

Fixes issue with positional_parameters_demo.sh showing parse errors when using echo "" inside if blocks.