### PR TITLE
feat: implement until loop w/ break/continue support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ src/
 #### **Parser** (`src/parser.rs`)
 
 - **AST Construction**: Builds Abstract Syntax Tree from token stream
-- **Control Structures**: Handles if/elif/else, case, for, while, functions
+- **Control Structures**: Handles if/elif/else, case, for, while, until, functions
 - **Pipeline Construction**: Creates pipeline structures for command chaining
 - **Redirection Parsing**: Processes I/O redirection operators
 - **Subshell Parsing**: Parses subshell expressions with proper nesting

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~90% POSIX compliant). 
   - `case` statements with glob pattern matching: `case word in pattern1|pattern2) commands ;; *.txt) commands ;; *) default ;; esac`
   - `for` loops: `for variable in item1 item2 item3; do commands; done`
   - `while` loops: `while condition; do commands; done`
+  - `until` loops: `until condition; do commands; done`
   - **Functions**: Complete function support with definition, calls, local variables, return statements, and recursion
     - Function definition: `name() { commands; }`
     - Function calls: `name arg1 arg2`
@@ -158,7 +159,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~90% POSIX compliant). 
 
 **File Descriptor Operations** - Complete FD table management with duplication (N>&M, N<&M), closing (N>&-, N<&-), and read/write (N<>) operations. Includes 30+ test cases for comprehensive coverage.
 
-**Complete Control Structures** - Full implementation of POSIX control structures including `for` loops, `while` loops, and function definitions with local variable scoping, return statements, and recursion support.
+**Complete Control Structures** - Full implementation of POSIX control structures including `for` loops, `while` loops, `until` loops, and function definitions with local variable scoping, return statements, and recursion support.
 
 **Function System** - Comprehensive function implementation with definition, calls, local variables (`local` keyword), return statements, recursion, and function introspection (`declare -f`).
 
@@ -913,6 +914,8 @@ Several features were fully implemented but not properly documented in previous 
 **For Loops** - Complete implementation with `for variable in items; do commands; done` syntax, supporting variable assignment, multiple items, and integration with all shell features.
 
 **While Loops** - Full implementation with `while condition; do commands; done` syntax, supporting complex conditions, nested loops, and proper exit code handling.
+
+**Until Loops** - Full implementation with `until condition; do commands; done` syntax, executing commands until the condition becomes true (inverse of while loops), supporting complex conditions, nested loops, and proper exit code handling.
 
 **Function System** - Comprehensive function implementation including:
 
@@ -1990,6 +1993,7 @@ Unlike script mode (running `./target/release/rush-sh script.sh`), the `source` 
 - Execute elif example script: `source examples/elif_example.sh`
 - Execute case example script: `source examples/case_example.sh`
 - Execute variables example script: `source examples/variables_example.sh`
+- Execute until loop demo: `source examples/until_demo.sh`
 - Execute complex example script with command substitution: `source examples/complex_example.sh`
 - Execute positional parameters demo: `source examples/positional_parameters_demo.sh`
 - Execute functions demo (comprehensive): `source examples/functions_demo.sh`
@@ -2020,13 +2024,14 @@ Unlike script mode (running `./target/release/rush-sh script.sh`), the `source` 
 - Use control structures:
   - If statement: `if true; then echo yes; else echo no; fi`
   - If-elif-else statement: `if false; then echo no; elif true; then echo yes; else echo maybe; fi`
+  - While loops: `count=0; while [ $count -lt 5 ]; do echo "Count: $count"; count=$((count + 1)); done`
+  - Until loops: `count=0; until [ $count -eq 5 ]; do echo "Count: $count"; count=$((count + 1)); done`
   - Case statement with glob patterns:
     - Simple match: `case hello in hello) echo match ;; *) echo no match ;; esac`
     - Glob patterns: `case file.txt in *.txt) echo "Text file" ;; *.jpg) echo "Image" ;; *) echo "Other" ;; esac`
     - Multiple patterns: `case file in *.txt|*.md) echo "Document" ;; *.exe|*.bin) echo "Executable" ;; *) echo "Other" ;; esac`
     - Character classes: `case letter in [abc]) echo "A, B, or C" ;; *) echo "Other letter" ;; esac`
   - For loops: `for i in 1 2 3; do echo "Number: $i"; done`
-  - While loops: `while [ $count -lt 5 ]; do echo "Count: $count"; count=$((count + 1)); done`
   - Loop control:
     - Break from loop: `for i in 1 2 3 4 5; do if [ $i -eq 3 ]; then break; fi; echo $i; done`
     - Continue to next iteration: `for i in 1 2 3 4 5; do if [ $i -eq 3 ]; then continue; fi; echo $i; done`
@@ -2302,7 +2307,7 @@ The test suite provides extensive coverage of:
 - **Subshells** (state isolation, exit code propagation, trap inheritance, depth limits, 60+ test cases)
 - **File descriptor operations** (duplication, closing, read/write modes, 30+ test cases)
 - Pipeline and redirection handling
-- Control structures (if-elif-else statements, case statements with glob patterns, for loops, while loops)
+- Control structures (if-elif-else statements, case statements with glob patterns, for loops, while loops, until loops)
 - **Functions** (definition, calls, local variables, return statements, recursion, introspection)
 - Command substitution (`$(...)` and `` `...` `` syntax, error handling, variable expansion)
 - **Arithmetic expansion** (`$((...))` syntax, operator precedence, variable integration, error handling)

--- a/TODO.md
+++ b/TODO.md
@@ -286,7 +286,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 ### Breakdown by Category
 
 - **Basic Execution**: 95% ✅
-- **Control Structures**: 95% ✅ (if/elif/else, case with glob patterns, for/while loops, functions with return, subshells, command grouping implemented)
+- **Control Structures**: 95% ✅ (if/elif/else, case with glob patterns, for/while/until loops, functions with return, subshells, command grouping implemented)
 - **Built-in Commands**: 74% ✅ (24 built-ins implemented out of 31 POSIX required)
 - **Expansions**: 98% ✅ (Parameter expansion with indirect expansion, arithmetic expansion, and brace expansion fully implemented)
 - **Redirections**: 95% ✅ (Full I/O redirection, here-documents, here-strings, and file descriptor operations implemented)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -292,7 +292,7 @@
                                 <ul>
                                     <li><strong>AST Construction:</strong> Builds Abstract Syntax Tree from token stream
                                     </li>
-                                    <li><strong>Control Structures:</strong> Handles if/elif/else, case, for, while,
+                                    <li><strong>Control Structures:</strong> Handles if/elif/else, case, for, while, until,
                                         functions</li>
                                     <li><strong>Pipeline Construction:</strong> Creates pipeline structures for command
                                         chaining</li>

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -411,7 +411,11 @@
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">while/until loops</span>
+                                <span class="item-text">while loops</span>
+                            </div>
+                            <div class="compliance-item implemented">
+                                <span class="status-icon">✅</span>
+                                <span class="item-text">until loops</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>

--- a/docs/features.html
+++ b/docs/features.html
@@ -486,6 +486,17 @@ done</code></pre>
                             </div>
 
                             <div class="example-group">
+                                <h4>Until Loops</h4>
+                                <div class="code-block">
+                                    <pre><code>count=1
+until [ $count -gt 5 ]; do
+    echo "Count: $count"
+    count=$((count + 1))
+done</code></pre>
+                                </div>
+                            </div>
+
+                            <div class="example-group">
                                 <h4>Loop Control</h4>
                                 <div class="code-block">
                                     <pre><code># Break - exit from loop

--- a/examples/until_demo.sh
+++ b/examples/until_demo.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env rush-sh
+
+# Until Loop Demo Script
+# Demonstrates POSIX-compliant until loop functionality
+
+echo "=== Until Loop Demo ==="
+echo
+
+# ============================================================================
+# Simple until loop
+# ============================================================================
+echo "1. Simple until loop:"
+echo "   count=0"
+echo "   until [ \$count -eq 5 ]; do"
+echo "     echo \"Count: \$count\""
+echo "     count=\$((count + 1))"
+echo "   done"
+echo
+echo "Output:"
+count=0
+until [ $count -eq 5 ]; do
+  echo "  Count: $count"
+  count=$((count + 1))
+done
+echo
+
+# ============================================================================
+# Until loop with variable modification
+# ============================================================================
+echo "2. Until loop with variable modification:"
+echo "   value=10"
+echo "   until [ \$value -le 0 ]; do"
+echo "     echo \"Countdown: \$value\""
+echo "     value=\$((value - 1))"
+echo "   done"
+echo "   echo \"Liftoff!\""
+echo
+echo "Output:"
+value=10
+until [ $value -le 0 ]; do
+  echo "  Countdown: $value"
+  value=$((value - 1))
+done
+echo "  Liftoff!"
+echo
+
+# ============================================================================
+# Until loop with break
+# ============================================================================
+echo "3. Until loop with break:"
+echo "   i=0"
+echo "   until [ \$i -eq 100 ]; do"
+echo "     echo \"Iteration: \$i\""
+echo "     i=\$((i + 1))"
+echo "     if [ \$i -eq 5 ]; then"
+echo "       echo \"Breaking at 5\""
+echo "       break"
+echo "     fi"
+echo "   done"
+echo
+echo "Output:"
+i=0
+until [ $i -eq 100 ]; do
+  echo "  Iteration: $i"
+  i=$((i + 1))
+  if [ $i -eq 5 ]; then
+    echo "  Breaking at 5"
+    break
+  fi
+done
+echo
+
+# ============================================================================
+# Until loop with continue
+# ============================================================================
+echo "4. Until loop with continue:"
+echo "   num=0"
+echo "   until [ \$num -eq 10 ]; do"
+echo "     num=\$((num + 1))"
+echo "     if [ \$((num % 2)) -eq 0 ]; then"
+echo "       continue"
+echo "     fi"
+echo "     echo \"Odd number: \$num\""
+echo "   done"
+echo
+echo "Output:"
+num=0
+until [ $num -eq 10 ]; do
+  num=$((num + 1))
+  if [ $((num % 2)) -eq 0 ]; then
+    continue
+  fi
+  echo "  Odd number: $num"
+done
+echo
+
+# ============================================================================
+# Nested until loops
+# ============================================================================
+echo "5. Nested until loops:"
+echo "   outer=0"
+echo "   until [ \$outer -eq 3 ]; do"
+echo "     echo \"Outer: \$outer\""
+echo "     inner=0"
+echo "     until [ \$inner -eq 3 ]; do"
+echo "       echo \"  Inner: \$inner\""
+echo "       inner=\$((inner + 1))"
+echo "     done"
+echo "     outer=\$((outer + 1))"
+echo "   done"
+echo
+echo "Output:"
+outer=0
+until [ $outer -eq 3 ]; do
+  echo "  Outer: $outer"
+  inner=0
+  until [ $inner -eq 3 ]; do
+    echo "    Inner: $inner"
+    inner=$((inner + 1))
+  done
+  outer=$((outer + 1))
+done
+echo
+
+# ============================================================================
+# Nested until loops with break
+# ============================================================================
+echo "6. Nested until loops with break (breaks inner loop only):"
+echo "   x=0"
+echo "   until [ \$x -eq 3 ]; do"
+echo "     echo \"Outer: \$x\""
+echo "     y=0"
+echo "     until [ \$y -eq 5 ]; do"
+echo "       echo \"  Inner: \$y\""
+echo "       if [ \$y -eq 2 ]; then"
+echo "         echo \"  Breaking inner loop\""
+echo "         break"
+echo "       fi"
+echo "       y=\$((y + 1))"
+echo "     done"
+echo "     x=\$((x + 1))"
+echo "   done"
+echo
+echo "Output:"
+x=0
+until [ $x -eq 3 ]; do
+  echo "  Outer: $x"
+  y=0
+  until [ $y -eq 5 ]; do
+    echo "    Inner: $y"
+    if [ $y -eq 2 ]; then
+      echo "    Breaking inner loop"
+      break
+    fi
+    y=$((y + 1))
+  done
+  x=$((x + 1))
+done
+echo
+
+# ============================================================================
+# Nested until loops with break 2
+# ============================================================================
+echo "7. Nested until loops with break 2 (breaks both loops):"
+echo "   a=0"
+echo "   until [ \$a -eq 5 ]; do"
+echo "     echo \"Outer: \$a\""
+echo "     b=0"
+echo "     until [ \$b -eq 5 ]; do"
+echo "       echo \"  Inner: \$b\""
+echo "       if [ \$a -eq 2 ] && [ \$b -eq 2 ]; then"
+echo "         echo \"  Breaking both loops\""
+echo "         break 2"
+echo "       fi"
+echo "       b=\$((b + 1))"
+echo "     done"
+echo "     a=\$((a + 1))"
+echo "   done"
+echo
+echo "Output:"
+a=0
+until [ $a -eq 5 ]; do
+  echo "  Outer: $a"
+  b=0
+  until [ $b -eq 5 ]; do
+    echo "    Inner: $b"
+    if [ $a -eq 2 ] && [ $b -eq 2 ]; then
+      echo "    Breaking both loops"
+      break 2
+    fi
+    b=$((b + 1))
+  done
+  a=$((a + 1))
+done
+echo
+
+# ============================================================================
+# Nested until loops with continue
+# ============================================================================
+echo "8. Nested until loops with continue (continues inner loop only):"
+echo "   m=0"
+echo "   until [ \$m -eq 3 ]; do"
+echo "     echo \"Outer: \$m\""
+echo "     n=0"
+echo "     until [ \$n -eq 4 ]; do"
+echo "       n=\$((n + 1))"
+echo "       if [ \$n -eq 2 ]; then"
+echo "         echo \"  Skipping 2\""
+echo "         continue"
+echo "       fi"
+echo "       echo \"  Inner: \$n\""
+echo "     done"
+echo "     m=\$((m + 1))"
+echo "   done"
+echo
+echo "Output:"
+m=0
+until [ $m -eq 3 ]; do
+  echo "  Outer: $m"
+  n=0
+  until [ $n -eq 4 ]; do
+    n=$((n + 1))
+    if [ $n -eq 2 ]; then
+      echo "    Skipping 2"
+      continue
+    fi
+    echo "    Inner: $n"
+  done
+  m=$((m + 1))
+done
+echo
+
+# ============================================================================
+# Nested until loops with continue 2
+# ============================================================================
+echo "9. Nested until loops with continue 2 (continues outer loop):"
+echo "   p=0"
+echo "   until [ \$p -eq 3 ]; do"
+echo "     echo \"Outer: \$p\""
+echo "     q=0"
+echo "     until [ \$q -eq 4 ]; do"
+echo "       echo \"  Inner: \$q\""
+echo "       if [ \$p -eq 1 ] && [ \$q -eq 2 ]; then"
+echo "         echo \"  Continuing outer loop\""
+echo "         p=\$((p + 1))"
+echo "         continue 2"
+echo "       fi"
+echo "       q=\$((q + 1))"
+echo "     done"
+echo "     echo \"  Finished inner loop for \$p\""
+echo "     p=\$((p + 1))"
+echo "   done"
+echo
+echo "Output:"
+p=0
+until [ $p -eq 3 ]; do
+  echo "  Outer: $p"
+  q=0
+  until [ $q -eq 4 ]; do
+    echo "    Inner: $q"
+    if [ $p -eq 1 ] && [ $q -eq 2 ]; then
+      echo "    Continuing outer loop"
+      p=$((p + 1))
+      continue 2
+    fi
+    q=$((q + 1))
+  done
+  echo "  Finished inner loop for $p"
+  p=$((p + 1))
+done
+echo
+
+# ============================================================================
+# Practical example: Waiting for a condition
+# ============================================================================
+echo "10. Practical example: Waiting for a condition"
+echo "    attempts=0"
+echo "    max_attempts=5"
+echo "    success=0"
+echo "    until [ \$success -eq 1 ] || [ \$attempts -ge \$max_attempts ]; do"
+echo "      attempts=\$((attempts + 1))"
+echo "      echo \"Attempt \$attempts of \$max_attempts...\""
+echo "      # Simulate random success (succeed on attempt 3)"
+echo "      if [ \$attempts -eq 3 ]; then"
+echo "        success=1"
+echo "        echo \"Success!\""
+echo "      fi"
+echo "    done"
+echo "    if [ \$success -eq 0 ]; then"
+echo "      echo \"Failed after \$max_attempts attempts\""
+echo "    fi"
+echo
+echo "Output:"
+attempts=0
+max_attempts=5
+success=0
+until [ $success -eq 1 ] || [ $attempts -ge $max_attempts ]; do
+  attempts=$((attempts + 1))
+  echo "  Attempt $attempts of $max_attempts..."
+  # Simulate random success (succeed on attempt 3)
+  if [ $attempts -eq 3 ]; then
+    success=1
+    echo "  Success!"
+  fi
+done
+if [ $success -eq 0 ]; then
+  echo "  Failed after $max_attempts attempts"
+fi
+echo
+
+# ============================================================================
+# Practical example: Countdown timer
+# ============================================================================
+echo "11. Practical example: Countdown timer"
+echo "    seconds=5"
+echo "    echo \"Starting countdown from \$seconds...\""
+echo "    until [ \$seconds -le 0 ]; do"
+echo "      echo \"\$seconds...\""
+echo "      seconds=\$((seconds - 1))"
+echo "    done"
+echo "    echo \"Time's up!\""
+echo
+echo "Output:"
+seconds=5
+echo "  Starting countdown from $seconds..."
+until [ $seconds -le 0 ]; do
+  echo "  $seconds..."
+  seconds=$((seconds - 1))
+done
+echo "  Time's up!"
+echo
+
+# ============================================================================
+# Practical example: Retry logic with exponential backoff
+# ============================================================================
+echo "12. Practical example: Retry logic with exponential backoff"
+echo "    retry=0"
+echo "    max_retries=4"
+echo "    delay=1"
+echo "    connected=0"
+echo "    until [ \$connected -eq 1 ] || [ \$retry -ge \$max_retries ]; do"
+echo "      retry=\$((retry + 1))"
+echo "      echo \"Connection attempt \$retry (delay: \${delay}s)...\""
+echo "      # Simulate connection (succeed on attempt 3)"
+echo "      if [ \$retry -eq 3 ]; then"
+echo "        connected=1"
+echo "        echo \"Connected!\""
+echo "      else"
+echo "        echo \"Failed. Retrying in \${delay}s...\""
+echo "        delay=\$((delay * 2))"
+echo "      fi"
+echo "    done"
+echo
+echo "Output:"
+retry=0
+max_retries=4
+delay=1
+connected=0
+until [ $connected -eq 1 ] || [ $retry -ge $max_retries ]; do
+  retry=$((retry + 1))
+  echo "  Connection attempt $retry (delay: ${delay}s)..."
+  # Simulate connection (succeed on attempt 3)
+  if [ $retry -eq 3 ]; then
+    connected=1
+    echo "  Connected!"
+  else
+    echo "  Failed. Retrying in ${delay}s..."
+    delay=$((delay * 2))
+  fi
+done
+echo
+
+# ============================================================================
+# Comparison: while vs until
+# ============================================================================
+echo "13. Comparison: while vs until"
+echo
+echo "While loop (continues while condition is true):"
+echo "   i=0"
+echo "   while [ \$i -lt 3 ]; do"
+echo "     echo \"i = \$i\""
+echo "     i=\$((i + 1))"
+echo "   done"
+echo
+echo "Output:"
+i=0
+while [ $i -lt 3 ]; do
+  echo "  i = $i"
+  i=$((i + 1))
+done
+echo
+echo "Until loop (continues until condition becomes true):"
+echo "   j=0"
+echo "   until [ \$j -eq 3 ]; do"
+echo "     echo \"j = \$j\""
+echo "     j=\$((j + 1))"
+echo "   done"
+echo
+echo "Output:"
+j=0
+until [ $j -eq 3 ]; do
+  echo "  j = $j"
+  j=$((j + 1))
+done
+echo
+
+echo "=== Demo Complete ==="

--- a/src/builtins/builtin_break.rs
+++ b/src/builtins/builtin_break.rs
@@ -268,4 +268,200 @@ mod tests {
 
         shell_state.exit_loop();
     }
+
+    #[test]
+    fn test_break_in_until_loop() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // until false; do output="$output$i"; i=$((i + 1)); if [ $i = "3" ]; then break; fi; done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["false".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i".to_string(),
+                },
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["break".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+            ])),
+        };
+
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("012".to_string()));
+    }
+
+    #[test]
+    fn test_break_in_nested_until_loops() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // Nested until loops with break
+        let inner_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "2".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["break".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+            ])),
+        };
+
+        let outer_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_loop,
+            ])),
+        };
+
+        let exit_code = execute(outer_loop, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        // Inner loop breaks at j=2, so we get: 10, 11 (then break), 20, 21 (then break)
+        assert_eq!(shell_state.get_var("output"), Some("10112021".to_string()));
+    }
+
+    #[test]
+    fn test_break_2_in_nested_until_loops() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // Nested until loops with break 2
+        let inner_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+                Ast::And {
+                    left: Box::new(Ast::Pipeline(vec![ShellCommand {
+                        args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                        redirections: vec![],
+                        compound: None,
+                    }])),
+                    right: Box::new(Ast::If {
+                        branches: vec![(
+                            Box::new(Ast::Pipeline(vec![ShellCommand {
+                                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "1".to_string()],
+                                redirections: vec![],
+                                compound: None,
+                            }])),
+                            Box::new(Ast::Pipeline(vec![ShellCommand {
+                                args: vec!["break".to_string(), "2".to_string()],
+                                redirections: vec![],
+                                compound: None,
+                            }])),
+                        )],
+                        else_branch: None,
+                    }),
+                },
+            ])),
+        };
+
+        let outer_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_loop,
+            ])),
+        };
+
+        let exit_code = execute(outer_loop, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("10111220".to_string()));
+    }
 }

--- a/src/builtins/builtin_continue.rs
+++ b/src/builtins/builtin_continue.rs
@@ -268,4 +268,205 @@ mod tests {
 
         shell_state.exit_loop();
     }
+
+    #[test]
+    fn test_continue_in_until_loop() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // until [ $i -ge 5 ]; do i=$((i + 1)); if [ $i = "3" ]; then continue; fi; output="$output$i"; done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "-ge".to_string(), "5".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["continue".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i".to_string(),
+                },
+            ])),
+        };
+
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("1245".to_string()));
+    }
+
+    #[test]
+    fn test_continue_in_nested_until_loops() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // Nested until loops with continue
+        let inner_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "2".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["continue".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+            ])),
+        };
+
+        let outer_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_loop,
+            ])),
+        };
+
+        let exit_code = execute(outer_loop, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        // Inner loop continues at j=2, so we get: 11, 13 (skip 12), 21, 23 (skip 22), 31, 33 (skip 32)
+        assert_eq!(shell_state.get_var("output"), Some("111321233133".to_string()));
+    }
+
+    #[test]
+    fn test_continue_2_in_nested_until_loops() {
+        let _lock = ENV_LOCK.lock().unwrap();
+
+        use crate::executor::execute;
+        use crate::parser::Ast;
+
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+
+        // Nested until loops with continue 2
+        let inner_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+                Ast::And {
+                    left: Box::new(Ast::Pipeline(vec![ShellCommand {
+                        args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                        redirections: vec![],
+                        compound: None,
+                    }])),
+                    right: Box::new(Ast::If {
+                        branches: vec![(
+                            Box::new(Ast::Pipeline(vec![ShellCommand {
+                                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "1".to_string()],
+                                redirections: vec![],
+                                compound: None,
+                            }])),
+                            Box::new(Ast::Pipeline(vec![ShellCommand {
+                                args: vec!["continue".to_string(), "2".to_string()],
+                                redirections: vec![],
+                                compound: None,
+                            }])),
+                        )],
+                        else_branch: None,
+                    }),
+                },
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+            ])),
+        };
+
+        let outer_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_loop,
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output-".to_string(),
+                },
+            ])),
+        };
+
+        let exit_code = execute(outer_loop, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        // After 21, continue 2 skips rest of inner loop and the "-" assignment, goes to next outer iteration
+        assert_eq!(shell_state.get_var("output"), Some("111213-313233-".to_string()));
+    }
 }

--- a/src/builtins/builtin_declare.rs
+++ b/src/builtins/builtin_declare.rs
@@ -222,6 +222,15 @@ fn format_ast_body(ast: &Ast, indent_level: usize) -> String {
             result.push_str(&format!("\n{}done", indent));
             result
         }
+        Ast::Until { condition, body } => {
+            let mut result = String::new();
+            result.push_str(&format!("{}until ", indent));
+            result.push_str(&format_ast_body(condition, 0));
+            result.push_str("; do\n");
+            result.push_str(&format_ast_body(body, indent_level + 1));
+            result.push_str(&format!("\n{}done", indent));
+            result
+        }
         Ast::FunctionDefinition { name, body } => {
             format!(
                 "{}() {{\n{}    {}\n{}}}\n",

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1307,6 +1307,81 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
 
             exit_code
         }
+        Ast::Until { condition, body } => {
+            let mut exit_code = 0;
+
+            // Enter loop context
+            shell_state.enter_loop();
+
+            // Execute the loop until condition is true (exit code 0)
+            loop {
+                // Evaluate the condition
+                let cond_exit = execute(*condition.clone(), shell_state);
+
+                // Check if we got an early return from a function
+                if shell_state.is_returning() {
+                    shell_state.exit_loop();
+                    return cond_exit;
+                }
+
+                // Check if exit was requested (e.g., from trap handler)
+                if shell_state.exit_requested {
+                    shell_state.exit_loop();
+                    return shell_state.exit_code;
+                }
+
+                // If condition is true (exit code 0), break
+                if cond_exit == 0 {
+                    break;
+                }
+
+                // Execute the body
+                exit_code = execute(*body.clone(), shell_state);
+
+                // Check if we got an early return from a function
+                if shell_state.is_returning() {
+                    shell_state.exit_loop();
+                    return exit_code;
+                }
+
+                // Check if exit was requested (e.g., from trap handler)
+                if shell_state.exit_requested {
+                    shell_state.exit_loop();
+                    return shell_state.exit_code;
+                }
+
+                // Check for break signal
+                if shell_state.is_breaking() {
+                    if shell_state.get_break_level() == 1 {
+                        // Break out of this loop
+                        shell_state.clear_break();
+                        break;
+                    } else {
+                        // Decrement level and propagate to outer loop
+                        shell_state.decrement_break_level();
+                        break;
+                    }
+                }
+
+                // Check for continue signal
+                if shell_state.is_continuing() {
+                    if shell_state.get_continue_level() == 1 {
+                        // Continue to next iteration of this loop
+                        shell_state.clear_continue();
+                        continue;
+                    } else {
+                        // Decrement level and propagate to outer loop
+                        shell_state.decrement_continue_level();
+                        break; // Exit this loop to continue outer loop
+                    }
+                }
+            }
+
+            // Exit loop context
+            shell_state.exit_loop();
+
+            exit_code
+        }
         Ast::FunctionDefinition { name, body } => {
             // Store function definition in shell state
             shell_state.define_function(name.clone(), *body);
@@ -3618,5 +3693,539 @@ mod tests {
         // continue returns 0, so the loop's exit code should be 0
         assert_eq!(exit_code, 0);
         assert_eq!(shell_state.get_var("count"), Some("2".to_string()));
+    }
+
+    // ========================================================================
+    // Until Loop Tests
+    // ========================================================================
+
+    #[test]
+    fn test_until_basic_loop() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("i", "0".to_string());
+        shell_state.set_var("output", "".to_string());
+        
+        // i=0; until [ $i = "3" ]; do output="$output$i"; i=$((i + 1)); done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i".to_string(),
+                },
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("012".to_string()));
+        assert_eq!(shell_state.get_var("i"), Some("3".to_string()));
+    }
+
+    #[test]
+    fn test_until_condition_initially_true() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("executed", "no".to_string());
+        
+        // until true; do executed="yes"; done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["true".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Assignment {
+                var: "executed".to_string(),
+                value: "yes".to_string(),
+            }),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        // Body should not execute since condition is true (exit code 0)
+        assert_eq!(shell_state.get_var("executed"), Some("no".to_string()));
+    }
+
+    #[test]
+    fn test_until_with_commands_in_body() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("count", "0".to_string());
+        
+        // count=0; until [ $count -ge 3 ]; do count=$((count + 1)); echo $count; done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$count".to_string(), "-ge".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "count".to_string(),
+                    value: "$((count + 1))".to_string(),
+                },
+                Ast::Pipeline(vec![ShellCommand {
+                    args: vec!["echo".to_string(), "$count".to_string()],
+                    redirections: vec![],
+                    compound: None,
+                }]),
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("count"), Some("3".to_string()));
+    }
+
+    #[test]
+    fn test_until_with_variable_modification() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("x", "1".to_string());
+        
+        // x=1; until [ $x -gt 5 ]; do x=$((x * 2)); done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$x".to_string(), "-gt".to_string(), "5".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Assignment {
+                var: "x".to_string(),
+                value: "$((x * 2))".to_string(),
+            }),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("x"), Some("8".to_string()));
+    }
+
+    #[test]
+    fn test_until_nested_loops() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+        
+        let inner_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let outer_loop = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_loop,
+            ])),
+        };
+        
+        let exit_code = execute(outer_loop, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("10112021".to_string()));
+    }
+
+    #[test]
+    fn test_until_with_break() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("i", "0".to_string());
+        shell_state.set_var("output", "".to_string());
+        
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["false".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i".to_string(),
+                },
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["break".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("012".to_string()));
+    }
+
+    #[test]
+    fn test_until_with_continue() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("i", "0".to_string());
+        shell_state.set_var("output", "".to_string());
+        
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "-ge".to_string(), "5".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::If {
+                    branches: vec![(
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "3".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                        Box::new(Ast::Pipeline(vec![ShellCommand {
+                            args: vec!["continue".to_string()],
+                            redirections: vec![],
+                            compound: None,
+                        }])),
+                    )],
+                    else_branch: None,
+                },
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i".to_string(),
+                },
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("1245".to_string()));
+    }
+
+    #[test]
+    fn test_until_empty_body() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("i", "0".to_string());
+        
+        // until true; do :; done (empty body with true condition)
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["true".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["true".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+    }
+
+    #[test]
+    fn test_until_with_command_substitution() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("count", "0".to_string());
+        shell_state.set_var("output", "".to_string());
+        
+        // until [ $(echo $count) = "3" ]; do output="$output$count"; count=$((count + 1)); done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$(echo $count)".to_string(), "=".to_string(), "3".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$count".to_string(),
+                },
+                Ast::Assignment {
+                    var: "count".to_string(),
+                    value: "$((count + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("012".to_string()));
+    }
+
+    #[test]
+    fn test_until_with_arithmetic_condition() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("x", "1".to_string());
+        shell_state.set_var("output", "".to_string());
+        
+        // x=1; until [ $((x * 2)) -gt 10 ]; do output="$output$x"; x=$((x + 1)); done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$((x * 2))".to_string(), "-gt".to_string(), "10".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$x".to_string(),
+                },
+                Ast::Assignment {
+                    var: "x".to_string(),
+                    value: "$((x + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("12345".to_string()));
+    }
+
+    #[test]
+    fn test_until_inside_for() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        
+        // for i in 1 2; do j=0; until [ $j = "2" ]; do output="$output$i$j"; j=$((j + 1)); done; done
+        let inner_until = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let outer_for = Ast::For {
+            variable: "i".to_string(),
+            items: vec!["1".to_string(), "2".to_string()],
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_until,
+            ])),
+        };
+        
+        let exit_code = execute(outer_for, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("10112021".to_string()));
+    }
+
+    #[test]
+    fn test_for_inside_until() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+        
+        // i=0; until [ $i = "2" ]; do for j in a b; do output="$output$i$j"; done; i=$((i + 1)); done
+        let inner_for = Ast::For {
+            variable: "j".to_string(),
+            items: vec!["a".to_string(), "b".to_string()],
+            body: Box::new(Ast::Assignment {
+                var: "output".to_string(),
+                value: "$output$i$j".to_string(),
+            }),
+        };
+        
+        let outer_until = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                inner_for,
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let exit_code = execute(outer_until, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("0a0b1a1b".to_string()));
+    }
+
+    #[test]
+    fn test_until_inside_while() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+        
+        let inner_until = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let outer_while = Ast::While {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "-lt".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_until,
+            ])),
+        };
+        
+        let exit_code = execute(outer_while, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("10112021".to_string()));
+    }
+
+    #[test]
+    fn test_while_inside_until() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("output", "".to_string());
+        shell_state.set_var("i", "0".to_string());
+        
+        let inner_while = Ast::While {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$j".to_string(), "-lt".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "output".to_string(),
+                    value: "$output$i$j".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "$((j + 1))".to_string(),
+                },
+            ])),
+        };
+        
+        let outer_until = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "2".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Assignment {
+                    var: "j".to_string(),
+                    value: "0".to_string(),
+                },
+                inner_while,
+            ])),
+        };
+        
+        let exit_code = execute(outer_until, &mut shell_state);
+        assert_eq!(exit_code, 0);
+        assert_eq!(shell_state.get_var("output"), Some("10112021".to_string()));
+    }
+
+    #[test]
+    fn test_until_preserves_exit_code() {
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("i", "0".to_string());
+        
+        // until [ $i = "1" ]; do i=$((i + 1)); false; done
+        let ast = Ast::Until {
+            condition: Box::new(Ast::Pipeline(vec![ShellCommand {
+                args: vec!["test".to_string(), "$i".to_string(), "=".to_string(), "1".to_string()],
+                redirections: vec![],
+                compound: None,
+            }])),
+            body: Box::new(Ast::Sequence(vec![
+                Ast::Assignment {
+                    var: "i".to_string(),
+                    value: "$((i + 1))".to_string(),
+                },
+                Ast::Pipeline(vec![ShellCommand {
+                    args: vec!["false".to_string()],
+                    redirections: vec![],
+                    compound: None,
+                }]),
+            ])),
+        };
+        
+        let exit_code = execute(ast, &mut shell_state);
+        // Last command in body was false (exit 1), so loop should return 1
+        assert_eq!(exit_code, 1);
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -41,6 +41,7 @@ pub enum Token {
     Do,
     Done,
     While,    // while
+    Until,    // until
     Break,    // break
     Continue, // continue
     And,      // &&
@@ -61,6 +62,7 @@ fn is_keyword(word: &str) -> Option<Token> {
         "return" => Some(Token::Return),
         "for" => Some(Token::For),
         "while" => Some(Token::While),
+        "until" => Some(Token::Until),
         "break" => Some(Token::Break),
         "continue" => Some(Token::Continue),
         "do" => Some(Token::Do),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,6 +30,10 @@ pub enum Ast {
         condition: Box<Ast>,
         body: Box<Ast>,
     },
+    Until {
+        condition: Box<Ast>,
+        body: Box<Ast>,
+    },
     FunctionDefinition {
         name: String,
         body: Box<Ast>,
@@ -145,10 +149,10 @@ fn skip_to_matching_fi(tokens: &[Token], i: &mut usize) {
 /// Handles nested loops correctly.
 fn skip_to_matching_done(tokens: &[Token], i: &mut usize) {
     let mut loop_depth = 1;
-    *i += 1; // Move past the 'for' or 'while' token
+    *i += 1; // Move past the 'for' or 'while' or 'until' token
     while *i < tokens.len() && loop_depth > 0 {
         match tokens[*i] {
-            Token::For | Token::While => loop_depth += 1,
+            Token::For | Token::While | Token::Until => loop_depth += 1,
             Token::Done => loop_depth -= 1,
             _ => {}
         }
@@ -207,13 +211,13 @@ pub fn parse(tokens: Vec<Token>) -> Result<Ast, String> {
                         j += 1;
                     }
                 }
-                Token::For | Token::While => {
+                Token::For | Token::While | Token::Until => {
                     // Skip to matching done
                     let mut for_depth = 1;
                     j += 1;
                     while j < tokens.len() && for_depth > 0 {
                         match tokens[j] {
-                            Token::For | Token::While => for_depth += 1,
+                            Token::For | Token::While | Token::Until => for_depth += 1,
                             Token::Done => for_depth -= 1,
                             _ => {}
                         }
@@ -415,6 +419,11 @@ fn parse_slice(tokens: &[Token]) -> Result<Ast, String> {
     // Check if it's a while loop
     if let Token::While = tokens[0] {
         return parse_while(tokens);
+    }
+
+    // Check if it's an until loop
+    if let Token::Until = tokens[0] {
+        return parse_until(tokens);
     }
 
     // Check if it's a function definition
@@ -914,7 +923,7 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
             i += 1; // Move past the 'for' token
             while i < tokens.len() {
                 match tokens[i] {
-                    Token::For | Token::While => depth += 1,
+                    Token::For | Token::While | Token::Until => depth += 1,
                     Token::Done => {
                         depth -= 1;
                         if depth == 0 {
@@ -932,7 +941,25 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
             i += 1; // Move past the 'while' token
             while i < tokens.len() {
                 match tokens[i] {
-                    Token::While | Token::For => depth += 1,
+                    Token::While | Token::For | Token::Until => depth += 1,
+                    Token::Done => {
+                        depth -= 1;
+                        if depth == 0 {
+                            i += 1; // Include the done
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+        } else if tokens[i] == Token::Until {
+            // For until loops, find the matching done
+            let mut depth = 1; // Start at 1 because we're already inside the until
+            i += 1; // Move past the 'until' token
+            while i < tokens.len() {
+                match tokens[i] {
+                    Token::Until | Token::For | Token::While => depth += 1,
                     Token::Done => {
                         depth -= 1;
                         if depth == 0 {
@@ -1399,6 +1426,9 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
             }
             Token::While => {
                 current_cmd.args.push("while".to_string());
+            }
+            Token::Until => {
+                current_cmd.args.push("until".to_string());
             }
             Token::Do => {
                 current_cmd.args.push("do".to_string());
@@ -1956,7 +1986,7 @@ fn parse_while(tokens: &[Token]) -> Result<Ast, String> {
     let mut depth = 0;
     while i < tokens.len() {
         match &tokens[i] {
-            Token::While | Token::For => {
+            Token::While | Token::For | Token::Until => {
                 depth += 1;
                 body_tokens.push(tokens[i].clone());
             }
@@ -2004,6 +2034,106 @@ fn parse_while(tokens: &[Token]) -> Result<Ast, String> {
     };
 
     Ok(Ast::While {
+        condition: Box::new(condition_ast),
+        body: Box::new(body_ast),
+    })
+}
+
+fn parse_until(tokens: &[Token]) -> Result<Ast, String> {
+    let mut i = 1; // Skip 'until'
+
+    // Parse condition until we hit 'do' or semicolon/newline
+    let mut cond_tokens = Vec::new();
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::Do => break,
+            Token::Semicolon | Token::Newline => {
+                i += 1;
+                // Check if next token is 'do'
+                if i < tokens.len() && tokens[i] == Token::Do {
+                    break;
+                }
+            }
+            _ => {
+                cond_tokens.push(tokens[i].clone());
+                i += 1;
+            }
+        }
+    }
+
+    if cond_tokens.is_empty() {
+        return Err("Expected condition after until".to_string());
+    }
+
+    // Skip any newlines before 'do'
+    while i < tokens.len() && tokens[i] == Token::Newline {
+        i += 1;
+    }
+
+    // Expect 'do'
+    if i >= tokens.len() || tokens[i] != Token::Do {
+        return Err("Expected 'do' in until loop".to_string());
+    }
+    i += 1;
+
+    // Skip any newlines after 'do'
+    while i < tokens.len() && tokens[i] == Token::Newline {
+        i += 1;
+    }
+
+    // Parse body until 'done'
+    let mut body_tokens = Vec::new();
+    let mut depth = 0;
+    while i < tokens.len() {
+        match &tokens[i] {
+            Token::While | Token::For | Token::Until => {
+                depth += 1;
+                body_tokens.push(tokens[i].clone());
+            }
+            Token::Done => {
+                if depth > 0 {
+                    depth -= 1;
+                    body_tokens.push(tokens[i].clone());
+                } else {
+                    break; // This done closes our until loop
+                }
+            }
+            Token::Newline => {
+                // Skip newlines but check what comes after
+                let mut j = i + 1;
+                while j < tokens.len() && tokens[j] == Token::Newline {
+                    j += 1;
+                }
+                if j < tokens.len() && depth == 0 && tokens[j] == Token::Done {
+                    i = j; // Skip to done
+                    break;
+                }
+                // Otherwise it's just a newline in the middle of commands
+                body_tokens.push(tokens[i].clone());
+            }
+            _ => {
+                body_tokens.push(tokens[i].clone());
+            }
+        }
+        i += 1;
+    }
+
+    if i >= tokens.len() || tokens[i] != Token::Done {
+        return Err("Expected 'done' to close until loop".to_string());
+    }
+
+    // Parse the condition
+    let condition_ast = parse_slice(&cond_tokens)?;
+
+    // Parse the body
+    let body_ast = if body_tokens.is_empty() {
+        // Empty body - create a no-op
+        create_empty_body_ast()
+    } else {
+        parse_commands_sequentially(&body_tokens)?
+    };
+
+    Ok(Ast::Until {
         condition: Box::new(condition_ast),
         body: Box::new(body_ast),
     })
@@ -2096,7 +2226,7 @@ fn parse_function_definition(tokens: &[Token]) -> Result<Ast, String> {
                 // Skip to matching fi
                 skip_to_matching_fi(tokens, &mut i);
             }
-            Token::For | Token::While => {
+            Token::For | Token::While | Token::Until => {
                 // Skip to matching done
                 skip_to_matching_done(tokens, &mut i);
             }

--- a/src/script_engine.rs
+++ b/src/script_engine.rs
@@ -189,6 +189,8 @@ pub fn execute_script(
     let mut for_depth = 0;
     let mut in_while_block = false;
     let mut while_depth = 0;
+    let mut in_until_block = false;
+    let mut until_depth = 0;
 
     // Track quote state across lines to handle multiline strings correctly
     let mut in_double_quote = false;
@@ -277,6 +279,9 @@ pub fn execute_script(
             } else if starts_with_keyword(line, "while") {
                 in_while_block = true;
                 while_depth += 1;
+            } else if starts_with_keyword(line, "until") {
+                in_until_block = true;
+                until_depth += 1;
             } else if {
                 let trimmed = line.trim();
                 trimmed == "{" || trimmed.starts_with("{ ") || trimmed.starts_with("{\t")
@@ -318,7 +323,7 @@ pub fn execute_script(
                 if if_depth == 0 {
                     in_if_block = false;
                     // Only execute if we're not inside a loop or other block
-                    if !in_for_block && !in_while_block && !in_function_block && !in_group_block && !in_case_block {
+                    if !in_for_block && !in_while_block && !in_until_block && !in_function_block && !in_group_block && !in_case_block {
                         execute_line(&current_block, shell_state);
                         current_block.clear();
 
@@ -349,6 +354,17 @@ pub fn execute_script(
                         break;
                     }
                 }
+            } else if in_until_block && contains_keyword(line, "done") {
+                until_depth -= 1;
+                if until_depth == 0 {
+                    in_until_block = false;
+                    execute_line(&current_block, shell_state);
+                    current_block.clear();
+
+                    if shell_state.exit_requested {
+                        break;
+                    }
+                }
             } else if in_case_block && contains_keyword(line, "esac") {
                 in_case_block = false;
                 execute_line(&current_block, shell_state);
@@ -363,6 +379,7 @@ pub fn execute_script(
                 && !in_group_block
                 && !in_for_block
                 && !in_while_block
+                && !in_until_block
             {
                 if let Some(delimiter) = line_contains_heredoc(&current_block, shell_state) {
                     i += 1;


### PR DESCRIPTION
- Add Until token to lexer
- Implement until loop parsing in parser
- Add until loop execution in executor
- Add until loop support in script engine
- Add 21 comprehensive tests for until loops
- Create until_demo.sh example script
- Update documentation (README, AGENTS.md, TODO.md, HTML)
- Fix parser token collection for until loops
- Add until block tracking in script engine