### PR TITLE
Support fd clobber override

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -204,6 +204,7 @@ pub fn execute_builtin(
             | Redirection::Append(file)
             | Redirection::FdInput(_, file)
             | Redirection::FdOutput(_, file)
+            | Redirection::FdOutputClobber(_, file)
             | Redirection::FdAppend(_, file)
             | Redirection::FdInputOutput(_, file) => {
                 files_to_expand.push(file.clone());
@@ -280,7 +281,7 @@ pub fn execute_builtin(
                     false, // truncate
                 )
             }
-            Redirection::FdOutput(fd, _) => {
+            Redirection::FdOutput(fd, _) | Redirection::FdOutputClobber(fd, _) => {
                 let file = expanded_file.as_ref().unwrap();
                 shell_state.fd_table.borrow_mut().open_fd(
                     *fd, file, false, // read

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -252,6 +252,7 @@ pub fn execute_builtin(
                     false, // write
                     false, // append
                     false, // truncate
+                    false, // create_new
                 )
             }
             Redirection::Output(_) | Redirection::OutputClobber(_) => {
@@ -261,6 +262,7 @@ pub fn execute_builtin(
                     true,  // write
                     false, // append
                     true,  // truncate
+                    false, // create_new
                 )
             }
             Redirection::Append(_) => {
@@ -270,6 +272,7 @@ pub fn execute_builtin(
                     true,  // write
                     true,  // append
                     false, // truncate
+                    false, // create_new
                 )
             }
             Redirection::FdInput(fd, _) => {
@@ -279,6 +282,7 @@ pub fn execute_builtin(
                     false, // write
                     false, // append
                     false, // truncate
+                    false, // create_new
                 )
             }
             Redirection::FdOutput(fd, _) | Redirection::FdOutputClobber(fd, _) => {
@@ -288,6 +292,7 @@ pub fn execute_builtin(
                     true,  // write
                     false, // append
                     true,  // truncate
+                    false, // create_new
                 )
             }
             Redirection::FdAppend(fd, _) => {
@@ -297,6 +302,7 @@ pub fn execute_builtin(
                     true,  // write
                     true,  // append
                     false, // truncate
+                    false, // create_new
                 )
             }
             Redirection::FdDuplicate(target_fd, source_fd) => shell_state
@@ -311,6 +317,7 @@ pub fn execute_builtin(
                     true,  // write
                     false, // append
                     false, // truncate
+                    false, // create_new
                 )
             }
             // Here-documents and here-strings are handled differently for builtins

--- a/src/builtins/builtin_declare.rs
+++ b/src/builtins/builtin_declare.rs
@@ -313,6 +313,7 @@ fn format_command(cmd: &crate::parser::ShellCommand) -> String {
             Redirection::Append(file) => result.push_str(&format!(" >> {}", file)),
             Redirection::FdInput(fd, file) => result.push_str(&format!(" {}<{}", fd, file)),
             Redirection::FdOutput(fd, file) => result.push_str(&format!(" {}>{}", fd, file)),
+            Redirection::FdOutputClobber(fd, file) => result.push_str(&format!(" {}>|{}", fd, file)),
             Redirection::FdAppend(fd, file) => result.push_str(&format!(" {}>>{}", fd, file)),
             Redirection::FdDuplicate(from, to) => result.push_str(&format!(" {}>&{}", from, to)),
             Redirection::FdClose(fd) => result.push_str(&format!(" {}>&-", fd)),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -831,6 +831,7 @@ fn apply_input_redirection(
                 false, // write
                 false, // append
                 false, // truncate
+                false, // clobber
             )?;
 
             // Also perform OS-level dup2
@@ -859,6 +860,7 @@ fn apply_input_redirection(
             false, // write
             false, // append
             false, // truncate
+            false, // clobber
         )?;
 
         // If we have an external command, set up the file descriptor in the child process
@@ -969,6 +971,7 @@ fn apply_output_redirection(
                 true,  // write
                 append,
                 !append, // truncate if not appending
+                false, // clobber
             )?;
         }
     } else {
@@ -997,6 +1000,7 @@ fn apply_output_redirection(
             true,  // write
             append,
             !append, // truncate if not appending
+            shell_state.options.noclobber && !force_clobber && !append, // create_new
         )?;
 
         // Also perform OS-level dup2 to ensure child processes inherit the redirection
@@ -1098,6 +1102,7 @@ fn apply_fd_input_output(
         true,  // write
         false, // append
         false, // truncate
+        false, // create_new
     )?;
 
     Ok(())

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -772,6 +772,9 @@ fn apply_redirections(
             Redirection::FdOutput(fd, file) => {
                 apply_output_redirection(*fd, file, false, false, shell_state, command.as_deref_mut())?;
             }
+            Redirection::FdOutputClobber(fd, file) => {
+                apply_output_redirection(*fd, file, false, true, shell_state, command.as_deref_mut())?;
+            }
             Redirection::FdAppend(fd, file) => {
                 apply_output_redirection(*fd, file, true, false, shell_state, command.as_deref_mut())?;
             }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -973,7 +973,23 @@ fn apply_output_redirection(
         }
     } else {
         // Current process redirection (builtins, command groups)
-        // We MUST update the file descriptor table for ALL FDs including 1 and 2
+        // Check noclobber before opening in fd_table
+        if shell_state.options.noclobber && !force_clobber && !append {
+            // Check if file exists before opening
+            if std::path::Path::new(&expanded_file).exists() {
+                let error_msg = if shell_state.colors_enabled {
+                    format!(
+                        "{}cannot overwrite existing file '{}' (noclobber is set)\x1b[0m",
+                        shell_state.color_scheme.error, expanded_file
+                    )
+                } else {
+                    format!("cannot overwrite existing file '{}' (noclobber is set)", expanded_file)
+                };
+                return Err(error_msg);
+            }
+        }
+        
+        // Now safe to open - we MUST update the file descriptor table for ALL FDs including 1 and 2
         shell_state.fd_table.borrow_mut().open_fd(
             fd,
             &expanded_file,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -17,6 +17,7 @@ pub enum Token {
     // File descriptor redirections
     RedirectFdIn(i32, String),     // N<file - redirect fd N from file
     RedirectFdOut(i32, String),    // N>file - redirect fd N to file
+    RedirectFdOutClobber(i32, String), // N>|file - redirect fd N to file with noclobber override
     RedirectFdAppend(i32, String), // N>>file - append fd N to file
     RedirectFdDup(i32, i32),       // N>&M or N<&M - duplicate fd M to fd N
     RedirectFdClose(i32),          // N>&- or N<&- - close fd N
@@ -778,8 +779,8 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     
                     if !filename.is_empty() {
                         if let Some(fd) = fd_num {
-                            // With fd number, use RedirectFdOut (clobber is implied by >|)
-                            tokens.push(Token::RedirectFdOut(fd, filename));
+                            // With fd number, use RedirectFdOutClobber for proper noclobber override
+                            tokens.push(Token::RedirectFdOutClobber(fd, filename));
                         } else {
                             // Without fd number, use RedirOutClobber
                             tokens.push(Token::RedirOutClobber);

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3514,7 +3514,7 @@ mod tests {
             vec![
                 Token::Word("echo".to_string()),
                 Token::Word("test".to_string()),
-                Token::RedirectFdOut(2, "errors.log".to_string())
+                Token::RedirectFdOutClobber(2, "errors.log".to_string())
             ]
         );
     }
@@ -3527,7 +3527,7 @@ mod tests {
             result,
             vec![
                 Token::Word("command".to_string()),
-                Token::RedirectFdOut(3, "file.txt".to_string())
+                Token::RedirectFdOutClobber(3, "file.txt".to_string())
             ]
         );
     }
@@ -3563,7 +3563,7 @@ mod tests {
             result,
             vec![
                 Token::Word("command".to_string()),
-                Token::RedirectFdOut(2, "error log.txt".to_string())
+                Token::RedirectFdOutClobber(2, "error log.txt".to_string())
             ]
         );
     }
@@ -3578,7 +3578,7 @@ mod tests {
                 Token::Word("command".to_string()),
                 Token::RedirOutClobber,
                 Token::Word("out.txt".to_string()),
-                Token::RedirectFdOut(2, "err.txt".to_string())
+                Token::RedirectFdOutClobber(2, "err.txt".to_string())
             ]
         );
     }
@@ -3606,11 +3606,11 @@ mod tests {
         
         // Test fd 0 (unusual but valid)
         let result = lex("cmd 0>| file", &shell_state).unwrap();
-        assert_eq!(result[1], Token::RedirectFdOut(0, "file".to_string()));
+        assert_eq!(result[1], Token::RedirectFdOutClobber(0, "file".to_string()));
         
         // Test fd 9
         let result = lex("cmd 9>| file", &shell_state).unwrap();
-        assert_eq!(result[1], Token::RedirectFdOut(9, "file".to_string()));
+        assert_eq!(result[1], Token::RedirectFdOutClobber(9, "file".to_string()));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,6 +85,8 @@ pub enum Redirection {
     FdInput(i32, String),
     /// Output to file with explicit fd: N> file
     FdOutput(i32, String),
+    /// Output to file with explicit fd and noclobber override: N>| file
+    FdOutputClobber(i32, String),
     /// Append to file with explicit fd: N>> file
     FdAppend(i32, String),
     /// Duplicate file descriptor: N>&M or N<&M
@@ -872,6 +874,10 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                         redirections.push(Redirection::FdOutput(*fd, file.clone()));
                         i += 1;
                     }
+                    Token::RedirectFdOutClobber(fd, file) => {
+                        redirections.push(Redirection::FdOutputClobber(*fd, file.clone()));
+                        i += 1;
+                    }
                     Token::RedirectFdIn(fd, file) => {
                         redirections.push(Redirection::FdInput(*fd, file.clone()));
                         i += 1;
@@ -1537,6 +1543,12 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                                 .push(Redirection::FdOutput(*fd, file.clone()));
                             i += 1;
                         }
+                        Token::RedirectFdOutClobber(fd, file) => {
+                            current_cmd
+                                .redirections
+                                .push(Redirection::FdOutputClobber(*fd, file.clone()));
+                            i += 1;
+                        }
                         Token::RedirectFdIn(fd, file) => {
                             current_cmd
                                 .redirections
@@ -1679,6 +1691,12 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                             current_cmd
                                 .redirections
                                 .push(Redirection::FdOutput(*fd, file.clone()));
+                            i += 1;
+                        }
+                        Token::RedirectFdOutClobber(fd, file) => {
+                            current_cmd
+                                .redirections
+                                .push(Redirection::FdOutputClobber(*fd, file.clone()));
                             i += 1;
                         }
                         Token::RedirectFdIn(fd, file) => {
@@ -1860,6 +1878,11 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                 current_cmd
                     .redirections
                     .push(Redirection::FdOutput(*fd, file.clone()));
+            }
+            Token::RedirectFdOutClobber(fd, file) => {
+                current_cmd
+                    .redirections
+                    .push(Redirection::FdOutputClobber(*fd, file.clone()));
             }
             Token::RedirectFdAppend(fd, file) => {
                 current_cmd

--- a/src/state.rs
+++ b/src/state.rs
@@ -107,7 +107,15 @@ impl FileDescriptorTable {
         write: bool,
         append: bool,
         truncate: bool,
+        create_new: bool,
     ) -> Result<(), String> {
+        let mut opts = OpenOptions::new();
+        if create_new {
+            opts.create_new(true); // Atomic check-and-create
+        } else if truncate {
+            opts.create(true).truncate(true);
+        }
+
         // Validate fd number
         if !(0..=1024).contains(&fd_num) {
             return Err(format!("Invalid file descriptor number: {}", fd_num));
@@ -412,34 +420,34 @@ impl Default for FileDescriptorTable {
 pub struct ShellOptions {
     /// -e: Exit on command failure
     pub errexit: bool,
-    
+
     /// -u: Treat unset variables as error
     pub nounset: bool,
-    
+
     /// -x: Print commands before execution
     pub xtrace: bool,
-    
+
     /// -v: Print input lines as read
     pub verbose: bool,
-    
+
     /// -n: Read but don't execute commands
     pub noexec: bool,
-    
+
     /// -f: Disable pathname expansion
     pub noglob: bool,
-    
+
     /// -C: Prevent overwriting files with redirection
     pub noclobber: bool,
-    
+
     /// -a: Auto-export all variables
     pub allexport: bool,
-    
+
     /// -b: Notify of job completion immediately
     pub notify: bool,
-    
+
     /// Ignore EOF (Ctrl+D) - not a standard POSIX option but commonly supported
     pub ignoreeof: bool,
-    
+
     /// -m: Enable job control (monitor)
     pub monitor: bool,
 }
@@ -500,7 +508,7 @@ impl ShellOptions {
             _ => None,
         }
     }
-    
+
     /// Set a shell option identified by its single-character short name.
     ///
     /// Sets the option corresponding to `name` to `value`. Recognized short names:
@@ -526,20 +534,50 @@ impl ShellOptions {
     /// ```
     pub fn set_by_short_name(&mut self, name: char, value: bool) -> Result<(), String> {
         match name {
-            'e' => { self.errexit = value; Ok(()) },
-            'u' => { self.nounset = value; Ok(()) },
-            'x' => { self.xtrace = value; Ok(()) },
-            'v' => { self.verbose = value; Ok(()) },
-            'n' => { self.noexec = value; Ok(()) },
-            'f' => { self.noglob = value; Ok(()) },
-            'C' => { self.noclobber = value; Ok(()) },
-            'a' => { self.allexport = value; Ok(()) },
-            'b' => { self.notify = value; Ok(()) },
-            'm' => { self.monitor = value; Ok(()) },
+            'e' => {
+                self.errexit = value;
+                Ok(())
+            }
+            'u' => {
+                self.nounset = value;
+                Ok(())
+            }
+            'x' => {
+                self.xtrace = value;
+                Ok(())
+            }
+            'v' => {
+                self.verbose = value;
+                Ok(())
+            }
+            'n' => {
+                self.noexec = value;
+                Ok(())
+            }
+            'f' => {
+                self.noglob = value;
+                Ok(())
+            }
+            'C' => {
+                self.noclobber = value;
+                Ok(())
+            }
+            'a' => {
+                self.allexport = value;
+                Ok(())
+            }
+            'b' => {
+                self.notify = value;
+                Ok(())
+            }
+            'm' => {
+                self.monitor = value;
+                Ok(())
+            }
             _ => Err(format!("Invalid option: -{}", name)),
         }
     }
-    
+
     /// Retrieve the value of a shell option by its long name.
     ///
     /// `name` is the option's full identifier (for example: "errexit", "nounset", "xtrace").
@@ -575,7 +613,7 @@ impl ShellOptions {
             _ => None,
         }
     }
-    
+
     /// Set a shell option by its long name.
     ///
     /// Sets the specified long-form option (for example `"errexit"` or `"nounset"`) to the provided boolean value.
@@ -593,21 +631,54 @@ impl ShellOptions {
     /// ```
     pub fn set_by_long_name(&mut self, name: &str, value: bool) -> Result<(), String> {
         match name {
-            "errexit" => { self.errexit = value; Ok(()) },
-            "nounset" => { self.nounset = value; Ok(()) },
-            "xtrace" => { self.xtrace = value; Ok(()) },
-            "verbose" => { self.verbose = value; Ok(()) },
-            "noexec" => { self.noexec = value; Ok(()) },
-            "noglob" => { self.noglob = value; Ok(()) },
-            "noclobber" => { self.noclobber = value; Ok(()) },
-            "allexport" => { self.allexport = value; Ok(()) },
-            "notify" => { self.notify = value; Ok(()) },
-            "ignoreeof" => { self.ignoreeof = value; Ok(()) },
-            "monitor" => { self.monitor = value; Ok(()) },
+            "errexit" => {
+                self.errexit = value;
+                Ok(())
+            }
+            "nounset" => {
+                self.nounset = value;
+                Ok(())
+            }
+            "xtrace" => {
+                self.xtrace = value;
+                Ok(())
+            }
+            "verbose" => {
+                self.verbose = value;
+                Ok(())
+            }
+            "noexec" => {
+                self.noexec = value;
+                Ok(())
+            }
+            "noglob" => {
+                self.noglob = value;
+                Ok(())
+            }
+            "noclobber" => {
+                self.noclobber = value;
+                Ok(())
+            }
+            "allexport" => {
+                self.allexport = value;
+                Ok(())
+            }
+            "notify" => {
+                self.notify = value;
+                Ok(())
+            }
+            "ignoreeof" => {
+                self.ignoreeof = value;
+                Ok(())
+            }
+            "monitor" => {
+                self.monitor = value;
+                Ok(())
+            }
             _ => Err(format!("Invalid option: {}", name)),
         }
     }
-    
+
     /// Lists all shell option names with their short-letter aliases and current values.
     ///
     /// Returns a vector of tuples `(long_name, short_name, value)` for every supported option.
@@ -1629,7 +1700,7 @@ mod tests {
         std::fs::write(temp_file, "test content").unwrap();
 
         // Open file for reading
-        let result = fd_table.open_fd(3, temp_file, true, false, false, false);
+        let result = fd_table.open_fd(3, temp_file, true, false, false, false, false);
         assert!(result.is_ok());
         assert!(fd_table.is_open(3));
 
@@ -1645,7 +1716,7 @@ mod tests {
         let temp_file = "/tmp/rush_test_fd_write.txt";
 
         // Open file for writing
-        let result = fd_table.open_fd(4, temp_file, false, true, false, true);
+        let result = fd_table.open_fd(4, temp_file, false, true, false, true, false);
         assert!(result.is_ok());
         assert!(fd_table.is_open(4));
 
@@ -1658,11 +1729,11 @@ mod tests {
         let mut fd_table = FileDescriptorTable::new();
 
         // Test invalid fd numbers
-        let result = fd_table.open_fd(-1, "/tmp/test.txt", true, false, false, false);
+        let result = fd_table.open_fd(-1, "/tmp/test.txt", true, false, false, false, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid file descriptor"));
 
-        let result = fd_table.open_fd(1025, "/tmp/test.txt", true, false, false, false);
+        let result = fd_table.open_fd(1025, "/tmp/test.txt", true, false, false, false, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid file descriptor"));
     }
@@ -1677,7 +1748,7 @@ mod tests {
 
         // Open file on fd 3
         fd_table
-            .open_fd(3, temp_file, true, false, false, false)
+            .open_fd(3, temp_file, true, false, false, false, false)
             .unwrap();
         assert!(fd_table.is_open(3));
 
@@ -1700,7 +1771,7 @@ mod tests {
 
         // Open file on fd 3
         fd_table
-            .open_fd(3, temp_file, true, false, false, false)
+            .open_fd(3, temp_file, true, false, false, false, false)
             .unwrap();
 
         // Duplicate fd 3 to itself (should be no-op)
@@ -1732,7 +1803,7 @@ mod tests {
 
         // Open file on fd 3
         fd_table
-            .open_fd(3, temp_file, true, false, false, false)
+            .open_fd(3, temp_file, true, false, false, false, false)
             .unwrap();
         assert!(fd_table.is_open(3));
 
@@ -1787,10 +1858,10 @@ mod tests {
         }
 
         fd_table
-            .open_fd(50, &temp_file1, true, false, false, false)
+            .open_fd(50, &temp_file1, true, false, false, false, false)
             .unwrap();
         fd_table
-            .open_fd(51, &temp_file2, true, false, false, false)
+            .open_fd(51, &temp_file2, true, false, false, false, false)
             .unwrap();
 
         // Save all fds
@@ -1824,7 +1895,7 @@ mod tests {
         // FileDescriptorTable::clear() just clears map. File drops.
 
         fd_table
-            .open_fd(50, temp_file, true, false, false, false)
+            .open_fd(50, temp_file, true, false, false, false, false)
             .unwrap();
         assert!(fd_table.is_open(50));
 
@@ -1846,7 +1917,7 @@ mod tests {
 
         // Open file on fd 3
         fd_table
-            .open_fd(3, temp_file, true, false, false, false)
+            .open_fd(3, temp_file, true, false, false, false, false)
             .unwrap();
 
         // Get Stdio for fd 3
@@ -1873,7 +1944,7 @@ mod tests {
 
         // Open file on fd 3
         fd_table
-            .open_fd(3, temp_file1, true, false, false, false)
+            .open_fd(3, temp_file1, true, false, false, false, false)
             .unwrap();
         assert!(fd_table.is_open(3));
 
@@ -1883,7 +1954,7 @@ mod tests {
 
         // Open another file on fd 5
         fd_table
-            .open_fd(5, temp_file2, true, false, false, false)
+            .open_fd(5, temp_file2, true, false, false, false, false)
             .unwrap();
         assert!(fd_table.is_open(5));
 
@@ -1920,7 +1991,7 @@ mod tests {
         {
             let mut fd_table = state.fd_table.borrow_mut();
             fd_table
-                .open_fd(3, temp_file, true, false, false, false)
+                .open_fd(3, temp_file, true, false, false, false, false)
                 .unwrap();
         }
 
@@ -2036,8 +2107,17 @@ mod tests {
 
         // Test all valid long options
         let long_opts = vec![
-            "errexit", "nounset", "xtrace", "verbose", "noexec", "noglob", "noclobber",
-            "allexport", "notify", "ignoreeof", "monitor",
+            "errexit",
+            "nounset",
+            "xtrace",
+            "verbose",
+            "noexec",
+            "noglob",
+            "noclobber",
+            "allexport",
+            "notify",
+            "ignoreeof",
+            "monitor",
         ];
         for opt in long_opts {
             assert!(options.set_by_long_name(opt, true).is_ok());
@@ -2054,7 +2134,7 @@ mod tests {
         options.xtrace = true;
 
         let all_options = options.get_all_options();
-        
+
         // Should have 11 options
         assert_eq!(all_options.len(), 11);
 
@@ -2085,13 +2165,13 @@ mod tests {
     #[test]
     fn test_shell_state_options_modification() {
         let mut state = ShellState::new();
-        
+
         state.options.errexit = true;
         assert!(state.options.errexit);
-        
+
         state.options.set_by_short_name('u', true).unwrap();
         assert!(state.options.nounset);
-        
+
         state.options.set_by_long_name("xtrace", true).unwrap();
         assert!(state.options.xtrace);
     }
@@ -2106,7 +2186,11 @@ mod tests {
 
         let result = options.set_by_long_name("invalid_option", true);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid option: invalid_option"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Invalid option: invalid_option")
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Add Token::RedirectFdOutClobber(i32, String) to lexer token enum
- Update lexer to emit RedirectFdOutClobber for fd-based >| redirections
- Add Redirection::FdOutputClobber(i32, String) to parser redirection enum
- Update parser to map Token::RedirectFdOutClobber to Redirection::FdOutputClobber
- Update executor to handle FdOutputClobber with force_clobber=true
- Update builtins.rs and builtin_declare.rs to handle new redirection variant

This allows commands like '2>|file' to properly override noclobber for
specific file descriptors, while '2>file' respects the noclobber option.
Previously, both were treated identically as RedirectFdOut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for fd-based output-clobber redirections (e.g., N>|filename) across command handling and formatting.
* **Behavior Changes**
  * Noclobber now consistently prevents accidental overwrites for per-process output redirections, honoring clobber/force/append semantics.
* **Bug Fixes**
  * Improved atomic create-new/open behavior for output redirections to reduce race/overwrite issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->