### PR TITLE
Fix redirection validation inconsistency in lexer

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -861,14 +861,10 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             tokens.push(Token::Word(filename));
                         }
                     } else {
-                        // No filename provided
-                        if fd_num.is_some() {
-                            return Err(
-                                "Invalid redirection: expected filename after >>".to_string()
-                            );
-                        } else {
-                            tokens.push(Token::RedirAppend);
-                        }
+                        // No filename provided - error
+                        return Err(
+                            "Invalid redirection: expected filename after >>".to_string()
+                        );
                     }
                 } else {
                     // Regular output redirection: > or N>
@@ -905,14 +901,10 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             tokens.push(Token::Word(filename));
                         }
                     } else {
-                        // No filename provided
-                        if fd_num.is_some() {
-                            return Err(
-                                "Invalid redirection: expected filename after >".to_string()
-                            );
-                        } else {
-                            tokens.push(Token::RedirOut);
-                        }
+                        // No filename provided - error
+                        return Err(
+                            "Invalid redirection: expected filename after >".to_string()
+                        );
                     }
                 }
             }
@@ -1122,14 +1114,10 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             tokens.push(Token::Word(filename));
                         }
                     } else {
-                        // No filename provided
-                        if fd_num.is_some() {
-                            return Err(
-                                "Invalid redirection: expected filename after <".to_string()
-                            );
-                        } else {
-                            tokens.push(Token::RedirIn);
-                        }
+                        // No filename provided - error
+                        return Err(
+                            "Invalid redirection: expected filename after <".to_string()
+                        );
                     }
                 }
             }


### PR DESCRIPTION
- Modified lex() function to validate all basic redirection forms (>, >>, <)
- Previously: lone '>' yielded Token::RedirOut without validation
- Now: all redirections without filenames return proper error messages
- Ensures consistency with documented behavior and other redirection forms
- Affected redirections: RedirOut, RedirAppend, RedirIn
- Error messages: 'Invalid redirection: expected filename after >', '>>', '<'
- All 151 lexer tests pass successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for redirection operators (>>, >, <) to consistently report "Invalid redirection: expected filename" when filenames are missing, providing clearer feedback for syntax errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->