### PR TITLE
Fix parse_single_command stopping rules for &&/|| operators

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -627,7 +627,10 @@ fn parse_single_command(tokens: &[Token]) -> Result<(Ast, usize), String> {
                 if i > start {
                     match &tokens[i] {
                         Token::And | Token::Or => {
-                            if brace_depth == 0 && paren_depth == 0 && !last_was_pipe {
+                            if brace_depth == 0 && paren_depth == 0 {
+                                if last_was_pipe {
+                                    return Err("Expected command after |".to_string());
+                                }
                                 break;
                             }
                         }


### PR DESCRIPTION
- Remove !last_was_pipe condition from depth check
- Add explicit error when &&/|| appears after pipe
- Ensures &&/|| always terminates command slice at depth 0
- Prevents parse_pipeline from including these operators in command slice
- Fixes issue where trailing tokens were ignored after partial parsing