### PR TITLE
Fix a bunch of clippy warnings

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -174,8 +174,7 @@ pub fn execute_builtin(
     };
 
     // If output_override is provided, use the old simple path for command substitution
-    if output_override.is_some() {
-        let mut output_writer = output_override.unwrap();
+    if let Some(mut output_writer) = output_override {
         let builtins = get_builtins();
         if let Some(builtin) = builtins
             .into_iter()

--- a/src/builtins/builtin_type.rs
+++ b/src/builtins/builtin_type.rs
@@ -146,11 +146,7 @@ impl super::Builtin for TypeBuiltin {
             }
         }
 
-        if all_found {
-            0
-        } else {
-            1
-        }
+        if all_found { 0 } else { 1 }
     }
 }
 
@@ -169,13 +165,13 @@ fn find_in_path(name: &str, shell_state: &ShellState) -> Option<String> {
         let full_path = format!("{}/{}", dir, name);
 
         // Check if file exists and is executable
-        if let Ok(metadata) = fs::metadata(&full_path) {
-            if metadata.is_file() {
-                // Check if executable (any execute bit set)
-                let permissions = metadata.permissions();
-                if permissions.mode() & 0o111 != 0 {
-                    return Some(full_path);
-                }
+        if let Ok(metadata) = fs::metadata(&full_path)
+            && metadata.is_file()
+        {
+            // Check if executable (any execute bit set)
+            let permissions = metadata.permissions();
+            if permissions.mode() & 0o111 != 0 {
+                return Some(full_path);
             }
         }
     }

--- a/src/executor/command.rs
+++ b/src/executor/command.rs
@@ -29,7 +29,10 @@ use super::{execute, execute_compound_in_pipeline, execute_compound_with_redirec
 /// // Note: execute_and_capture_output is a crate-internal function
 /// // This example is for documentation only
 /// ```
-pub(crate) fn execute_and_capture_output(ast: Ast, shell_state: &mut ShellState) -> Result<String, String> {
+pub(crate) fn execute_and_capture_output(
+    ast: Ast,
+    shell_state: &mut ShellState,
+) -> Result<String, String> {
     // Create a pipe to capture stdout
     let (reader, writer) = pipe().map_err(|e| format!("Failed to create pipe: {}", e))?;
 
@@ -226,25 +229,25 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
     // Exception: The 'set' builtin must always execute to allow disabling noexec
     // IMPORTANT: Check this BEFORE processing redirections to prevent side effects
     let is_set_builtin = !cmd.args.is_empty() && cmd.args[0] == "set";
-    
+
     if shell_state.options.noexec && !is_set_builtin {
         return 0; // Return success without executing (no side effects)
     }
 
     if cmd.args.is_empty() {
         // No command, but may have redirections - process them for side effects
-        if !cmd.redirections.is_empty() {
-            if let Err(e) = apply_redirections(&cmd.redirections, shell_state, None) {
-                if shell_state.colors_enabled {
-                    eprintln!(
-                        "{}Redirection error: {}\x1b[0m",
-                        shell_state.color_scheme.error, e
-                    );
-                } else {
-                    eprintln!("Redirection error: {}", e);
-                }
-                return 1;
+        if !cmd.redirections.is_empty()
+            && let Err(e) = apply_redirections(&cmd.redirections, shell_state, None)
+        {
+            if shell_state.colors_enabled {
+                eprintln!(
+                    "{}Redirection error: {}\x1b[0m",
+                    shell_state.color_scheme.error, e
+                );
+            } else {
+                eprintln!("Redirection error: {}", e);
             }
+            return 1;
         }
         return 0;
     }
@@ -263,16 +266,16 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
     // Print command if xtrace is enabled (-x)
     if shell_state.options.xtrace {
         // Get PS4 prompt (default: "+ ")
-        let ps4 = shell_state.get_var("PS4").unwrap_or_else(|| "+ ".to_string());
-        
+        let ps4 = shell_state
+            .get_var("PS4")
+            .unwrap_or_else(|| "+ ".to_string());
+
         // Print the command with expanded arguments to stderr
         let command_str = expanded_args.join(" ");
         if shell_state.colors_enabled {
             eprintln!(
                 "{}{}{}\x1b[0m",
-                shell_state.color_scheme.builtin,
-                ps4,
-                command_str
+                shell_state.color_scheme.builtin, ps4, command_str
             );
         } else {
             eprintln!("{}{}", ps4, command_str);
@@ -330,7 +333,8 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
             && exit_code != 0
             && !shell_state.in_condition
             && !shell_state.in_logical_chain
-            && !shell_state.in_negation {
+            && !shell_state.in_negation
+        {
             // Set exit_requested flag to trigger shell exit
             shell_state.exit_requested = true;
             shell_state.exit_code = exit_code;
@@ -377,7 +381,7 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
                     let var_name = &assignment[..eq_pos];
                     let var_value = &assignment[eq_pos + 1..];
                     shell_state.set_var(var_name, var_value.to_string());
-                    
+
                     // Auto-export if allexport option (-a) is enabled
                     if shell_state.options.allexport {
                         shell_state.export_var(var_name);
@@ -386,18 +390,18 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
             }
 
             // Process redirections even without a command
-            if !cmd.redirections.is_empty() {
-                if let Err(e) = apply_redirections(&cmd.redirections, shell_state, None) {
-                    if shell_state.colors_enabled {
-                        eprintln!(
-                            "{}Redirection error: {}\x1b[0m",
-                            shell_state.color_scheme.error, e
-                        );
-                    } else {
-                        eprintln!("Redirection error: {}", e);
-                    }
-                    return 1;
+            if !cmd.redirections.is_empty()
+                && let Err(e) = apply_redirections(&cmd.redirections, shell_state, None)
+            {
+                if shell_state.colors_enabled {
+                    eprintln!(
+                        "{}Redirection error: {}\x1b[0m",
+                        shell_state.color_scheme.error, e
+                    );
+                } else {
+                    eprintln!("Redirection error: {}", e);
                 }
+                return 1;
             }
             return 0;
         }
@@ -460,10 +464,10 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
             let mut fds = Vec::new();
 
             for fd_num in 3..=9 {
-                if fd_table.is_open(fd_num) {
-                    if let Some(raw_fd) = fd_table.get_raw_fd(fd_num) {
-                        fds.push((fd_num, raw_fd));
-                    }
+                if fd_table.is_open(fd_num)
+                    && let Some(raw_fd) = fd_table.get_raw_fd(fd_num)
+                {
+                    fds.push((fd_num, raw_fd));
                 }
             }
 
@@ -490,16 +494,13 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
         // closure capture keeps the file handles alive
         match command.spawn() {
             Ok(mut child) => {
-                // If capturing, read stdout
-                if capturing {
-                    if let Some(mut stdout) = child.stdout.take() {
-                        use std::io::Read;
-                        let mut output = Vec::new();
-                        if stdout.read_to_end(&mut output).is_ok() {
-                            if let Some(ref capture_buffer) = shell_state.capture_output {
-                                capture_buffer.borrow_mut().extend_from_slice(&output);
-                            }
-                        }
+                if capturing && let Some(mut stdout) = child.stdout.take() {
+                    use std::io::Read;
+                    let mut output = Vec::new();
+                    if stdout.read_to_end(&mut output).is_ok()
+                        && let Some(ref capture_buffer) = shell_state.capture_output
+                    {
+                        capture_buffer.borrow_mut().extend_from_slice(&output);
                     }
                 }
 
@@ -528,7 +529,8 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
                     && exit_code != 0
                     && !shell_state.in_condition
                     && !shell_state.in_logical_chain
-                    && !shell_state.in_negation {
+                    && !shell_state.in_negation
+                {
                     // Set exit_requested flag to trigger shell exit
                     shell_state.exit_requested = true;
                     shell_state.exit_code = exit_code;
@@ -559,10 +561,10 @@ pub(crate) fn execute_pipeline(commands: &[ShellCommand], shell_state: &mut Shel
     // Check noexec option (-n): Read commands but don't execute them
     // Exception: The 'set' builtin must always execute to allow disabling noexec
     // For pipelines, check if any command is 'set', otherwise skip execution
-    let has_set_builtin = commands.iter().any(|cmd| {
-        !cmd.args.is_empty() && cmd.args[0] == "set"
-    });
-    
+    let has_set_builtin = commands
+        .iter()
+        .any(|cmd| !cmd.args.is_empty() && cmd.args[0] == "set");
+
     if shell_state.options.noexec && !has_set_builtin {
         return 0; // Return success without executing (no side effects)
     }

--- a/src/executor/redirection.rs
+++ b/src/executor/redirection.rs
@@ -446,15 +446,13 @@ fn apply_output_redirection(
                             expanded_file
                         )
                     }
+                } else if shell_state.colors_enabled {
+                    format!(
+                        "{}Cannot create {}: {}\x1b[0m",
+                        shell_state.color_scheme.error, expanded_file, e
+                    )
                 } else {
-                    if shell_state.colors_enabled {
-                        format!(
-                            "{}Cannot create {}: {}\x1b[0m",
-                            shell_state.color_scheme.error, expanded_file, e
-                        )
-                    } else {
-                        format!("Cannot create {}: {}", expanded_file, e)
-                    }
+                    format!("Cannot create {}: {}", expanded_file, e)
                 }
             })?
     } else {
@@ -655,10 +653,10 @@ fn apply_heredoc_redirection(
         .map_err(|e| format!("Failed to write here-document content: {}", e))?;
 
     // Apply to stdin if fd is 0
-    if fd == 0 {
-        if let Some(cmd) = command {
-            cmd.stdin(Stdio::from(reader));
-        }
+    if fd == 0
+        && let Some(cmd) = command
+    {
+        cmd.stdin(Stdio::from(reader));
     }
 
     Ok(())
@@ -681,10 +679,10 @@ fn apply_herestring_redirection(
         .map_err(|e| format!("Failed to write here-string content: {}", e))?;
 
     // Apply to stdin if fd is 0
-    if fd == 0 {
-        if let Some(cmd) = command {
-            cmd.stdin(Stdio::from(reader));
-        }
+    if fd == 0
+        && let Some(cmd) = command
+    {
+        cmd.stdin(Stdio::from(reader));
     }
 
     Ok(())

--- a/src/executor/redirection.rs
+++ b/src/executor/redirection.rs
@@ -64,9 +64,9 @@ use std::os::fd::AsRawFd;
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 
+use super::expansion::expand_variables_in_string;
 use crate::parser::Redirection;
 use crate::state::ShellState;
-use super::expansion::expand_variables_in_string;
 
 /// Atomically write data to a file, respecting noclobber settings
 ///
@@ -80,7 +80,7 @@ fn write_file_with_noclobber(
     shell_state: &ShellState,
 ) -> Result<(), String> {
     use std::fs::OpenOptions;
-    
+
     if noclobber && !force_clobber {
         // Atomic check-and-create: fails if file exists
         let mut file = OpenOptions::new()
@@ -95,53 +95,55 @@ fn write_file_with_noclobber(
                             shell_state.color_scheme.error, path
                         )
                     } else {
-                        format!("cannot overwrite existing file '{}' (noclobber is set)", path)
-                    }
-                } else {
-                    if shell_state.colors_enabled {
                         format!(
-                            "{}Cannot create {}: {}\x1b[0m",
-                            shell_state.color_scheme.error, path, e
+                            "cannot overwrite existing file '{}' (noclobber is set)",
+                            path
                         )
-                    } else {
-                        format!("Cannot create {}: {}", path, e)
                     }
-                }
-            })?;
-        
-        file.write_all(data)
-            .map_err(|e| {
-                if shell_state.colors_enabled {
+                } else if shell_state.colors_enabled {
                     format!(
-                        "{}Failed to write to {}: {}\x1b[0m",
+                        "{}Cannot create {}: {}\x1b[0m",
                         shell_state.color_scheme.error, path, e
                     )
                 } else {
-                    format!("Failed to write to {}: {}", path, e)
+                    format!("Cannot create {}: {}", path, e)
                 }
             })?;
+
+        file.write_all(data).map_err(|e| {
+            if shell_state.colors_enabled {
+                format!(
+                    "{}Failed to write to {}: {}\x1b[0m",
+                    shell_state.color_scheme.error, path, e
+                )
+            } else {
+                format!("Failed to write to {}: {}", path, e)
+            }
+        })?;
     } else {
         // Allow overwriting (normal behavior or force_clobber)
-        std::fs::write(path, data)
-            .map_err(|e| {
-                if shell_state.colors_enabled {
-                    format!(
-                        "{}Cannot write to {}: {}\x1b[0m",
-                        shell_state.color_scheme.error, path, e
-                    )
-                } else {
-                    format!("Cannot write to {}: {}", path, e)
-                }
-            })?;
+        std::fs::write(path, data).map_err(|e| {
+            if shell_state.colors_enabled {
+                format!(
+                    "{}Cannot write to {}: {}\x1b[0m",
+                    shell_state.color_scheme.error, path, e
+                )
+            } else {
+                format!("Cannot write to {}: {}", path, e)
+            }
+        })?;
     }
-    
+
     Ok(())
 }
 
 /// Collect here-document content from stdin until the specified delimiter is found
 /// This function reads from stdin line by line until it finds a line that exactly matches the delimiter
 /// If shell_state has pending_heredoc_content, it uses that instead (for script execution)
-pub(crate) fn collect_here_document_content(delimiter: &str, shell_state: &mut ShellState) -> String {
+pub(crate) fn collect_here_document_content(
+    delimiter: &str,
+    shell_state: &mut ShellState,
+) -> String {
     // Check if we have pending here-document content from script execution
     if let Some(content) = shell_state.pending_heredoc_content.take() {
         return content;
@@ -222,25 +224,67 @@ pub fn apply_redirections(
                 apply_input_redirection(0, file, shell_state, command.as_deref_mut())?;
             }
             Redirection::Output(file) => {
-                apply_output_redirection(1, file, false, false, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    1,
+                    file,
+                    false,
+                    false,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::OutputClobber(file) => {
-                apply_output_redirection(1, file, false, true, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    1,
+                    file,
+                    false,
+                    true,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::Append(file) => {
-                apply_output_redirection(1, file, true, false, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    1,
+                    file,
+                    true,
+                    false,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::FdInput(fd, file) => {
                 apply_input_redirection(*fd, file, shell_state, command.as_deref_mut())?;
             }
             Redirection::FdOutput(fd, file) => {
-                apply_output_redirection(*fd, file, false, false, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    *fd,
+                    file,
+                    false,
+                    false,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::FdOutputClobber(fd, file) => {
-                apply_output_redirection(*fd, file, false, true, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    *fd,
+                    file,
+                    false,
+                    true,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::FdAppend(fd, file) => {
-                apply_output_redirection(*fd, file, true, false, shell_state, command.as_deref_mut())?;
+                apply_output_redirection(
+                    *fd,
+                    file,
+                    true,
+                    false,
+                    shell_state,
+                    command.as_deref_mut(),
+                )?;
             }
             Redirection::FdDuplicate(target_fd, source_fd) => {
                 apply_fd_duplication(*target_fd, *source_fd, shell_state, command.as_deref_mut())?;
@@ -300,12 +344,12 @@ fn apply_input_redirection(
 
             // Also perform OS-level dup2
             let raw_fd = shell_state.fd_table.borrow().get_raw_fd(0);
-            if let Some(rfd) = raw_fd {
-                if rfd != 0 {
-                    unsafe {
-                        if libc::dup2(rfd, 0) < 0 {
-                            return Err(format!("Failed to dup2 fd {} to 0", rfd));
-                        }
+            if let Some(rfd) = raw_fd
+                && rfd != 0
+            {
+                unsafe {
+                    if libc::dup2(rfd, 0) < 0 {
+                        return Err(format!("Failed to dup2 fd {} to 0", rfd));
                     }
                 }
             }
@@ -375,7 +419,10 @@ fn apply_output_redirection(
             .open(&expanded_file)
             .map_err(|e| {
                 if shell_state.colors_enabled {
-                    format!("{}Cannot open {}: {}\x1b[0m", shell_state.color_scheme.error, expanded_file, e)
+                    format!(
+                        "{}Cannot open {}: {}\x1b[0m",
+                        shell_state.color_scheme.error, expanded_file, e
+                    )
                 } else {
                     format!("Cannot open {}: {}", expanded_file, e)
                 }
@@ -394,11 +441,17 @@ fn apply_output_redirection(
                             shell_state.color_scheme.error, expanded_file
                         )
                     } else {
-                        format!("cannot overwrite existing file '{}' (noclobber is set)", expanded_file)
+                        format!(
+                            "cannot overwrite existing file '{}' (noclobber is set)",
+                            expanded_file
+                        )
                     }
                 } else {
                     if shell_state.colors_enabled {
-                        format!("{}Cannot create {}: {}\x1b[0m", shell_state.color_scheme.error, expanded_file, e)
+                        format!(
+                            "{}Cannot create {}: {}\x1b[0m",
+                            shell_state.color_scheme.error, expanded_file, e
+                        )
                     } else {
                         format!("Cannot create {}: {}", expanded_file, e)
                     }
@@ -406,14 +459,16 @@ fn apply_output_redirection(
             })?
     } else {
         // Normal create (truncate) or force_clobber
-        File::create(&expanded_file)
-            .map_err(|e| {
-                if shell_state.colors_enabled {
-                    format!("{}Cannot create {}: {}\x1b[0m", shell_state.color_scheme.error, expanded_file, e)
-                } else {
-                    format!("Cannot create {}: {}", expanded_file, e)
-                }
-            })?
+        File::create(&expanded_file).map_err(|e| {
+            if shell_state.colors_enabled {
+                format!(
+                    "{}Cannot create {}: {}\x1b[0m",
+                    shell_state.color_scheme.error, expanded_file, e
+                )
+            } else {
+                format!("Cannot create {}: {}", expanded_file, e)
+            }
+        })?
     };
 
     if let Some(cmd) = command {
@@ -435,7 +490,7 @@ fn apply_output_redirection(
                 true,  // write
                 append,
                 !append, // truncate if not appending
-                false, // clobber
+                false,   // clobber
             )?;
         }
     } else {
@@ -450,12 +505,15 @@ fn apply_output_redirection(
                         shell_state.color_scheme.error, expanded_file
                     )
                 } else {
-                    format!("cannot overwrite existing file '{}' (noclobber is set)", expanded_file)
+                    format!(
+                        "cannot overwrite existing file '{}' (noclobber is set)",
+                        expanded_file
+                    )
                 };
                 return Err(error_msg);
             }
         }
-        
+
         // Now safe to open - we MUST update the file descriptor table for ALL FDs including 1 and 2
         shell_state.fd_table.borrow_mut().open_fd(
             fd,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -5,8 +5,8 @@
 
 pub mod token;
 
-pub use token::{is_shell_keyword, Token};
 use token::is_keyword;
+pub use token::{Token, is_shell_keyword};
 
 use std::collections::HashSet;
 use std::env;
@@ -30,12 +30,10 @@ fn flush_current_token(current: &mut String, tokens: &mut Vec<Token>, was_quoted
     if !current.is_empty() {
         // Only check for keywords if the word was NOT quoted
         // Quoted strings like "done" should always be Word tokens, not keyword tokens
-        if !was_quoted {
-            if let Some(keyword) = is_keyword(current) {
-                tokens.push(keyword);
-                current.clear();
-                return;
-            }
+        if !was_quoted && let Some(keyword) = is_keyword(current) {
+            tokens.push(keyword);
+            current.clear();
+            return;
         }
         tokens.push(Token::Word(current.clone()));
         current.clear();
@@ -602,25 +600,27 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
             '!' if !in_double_quote && !in_single_quote => {
                 // Only emit Token::Bang if ! appears at command start position
                 // Command start is: beginning of input, after whitespace/newline/semicolon, or after operators
-                let is_command_start = current.is_empty() && (
-                    tokens.is_empty() ||
-                    matches!(tokens.last(), Some(
-                        Token::Newline |
-                        Token::Semicolon |
-                        Token::And |
-                        Token::Or |
-                        Token::Then |
-                        Token::Else |
-                        Token::Elif |
-                        Token::Do |
-                        Token::While |
-                        Token::Until |
-                        Token::If |
-                        Token::LeftParen |
-                        Token::LeftBrace
-                    ))
-                );
-                
+                let is_command_start = current.is_empty()
+                    && (tokens.is_empty()
+                        || matches!(
+                            tokens.last(),
+                            Some(
+                                Token::Newline
+                                    | Token::Semicolon
+                                    | Token::And
+                                    | Token::Or
+                                    | Token::Then
+                                    | Token::Else
+                                    | Token::Elif
+                                    | Token::Do
+                                    | Token::While
+                                    | Token::Until
+                                    | Token::If
+                                    | Token::LeftParen
+                                    | Token::LeftBrace
+                            )
+                        ));
+
                 if is_command_start {
                     flush_current_token(&mut current, &mut tokens, false);
                     chars.next(); // consume !
@@ -664,14 +664,14 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                 if let Some(&'|') = chars.peek() {
                     // This is >| (noclobber override)
                     chars.next(); // consume |
-                    
+
                     skip_whitespace(&mut chars);
-                    
+
                     // Collect the filename (handle quotes)
                     let mut filename = String::new();
                     let mut in_filename_quote = false;
                     let mut filename_quote_char = ' ';
-                    
+
                     while let Some(&ch) = chars.peek() {
                         if !in_filename_quote && (ch == '"' || ch == '\'') {
                             in_filename_quote = true;
@@ -680,8 +680,15 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         } else if in_filename_quote && ch == filename_quote_char {
                             in_filename_quote = false;
                             chars.next(); // consume quote but don't add to filename
-                        } else if !in_filename_quote && (ch == ' ' || ch == '\t' || ch == '\n'
-                            || ch == ';' || ch == '|' || ch == '&' || ch == '>' || ch == '<')
+                        } else if !in_filename_quote
+                            && (ch == ' '
+                                || ch == '\t'
+                                || ch == '\n'
+                                || ch == ';'
+                                || ch == '|'
+                                || ch == '&'
+                                || ch == '>'
+                                || ch == '<')
                         {
                             break;
                         } else {
@@ -689,7 +696,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                             chars.next();
                         }
                     }
-                    
+
                     if !filename.is_empty() {
                         if let Some(fd) = fd_num {
                             // With fd number, use RedirectFdOutClobber for proper noclobber override
@@ -747,7 +754,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     let mut filename = String::new();
                     let mut in_filename_quote = false;
                     let mut filename_quote_char = ' ';
-                    
+
                     while let Some(&ch) = chars.peek() {
                         if !in_filename_quote && (ch == '"' || ch == '\'') {
                             in_filename_quote = true;
@@ -756,8 +763,15 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         } else if in_filename_quote && ch == filename_quote_char {
                             in_filename_quote = false;
                             chars.next(); // consume quote but don't add to filename
-                        } else if !in_filename_quote && (ch == ' ' || ch == '\t' || ch == '\n'
-                            || ch == ';' || ch == '|' || ch == '&' || ch == '>' || ch == '<')
+                        } else if !in_filename_quote
+                            && (ch == ' '
+                                || ch == '\t'
+                                || ch == '\n'
+                                || ch == ';'
+                                || ch == '|'
+                                || ch == '&'
+                                || ch == '>'
+                                || ch == '<')
                         {
                             break;
                         } else {
@@ -775,9 +789,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         }
                     } else {
                         // No filename provided - error
-                        return Err(
-                            "Invalid redirection: expected filename after >>".to_string()
-                        );
+                        return Err("Invalid redirection: expected filename after >>".to_string());
                     }
                 } else {
                     // Regular output redirection: > or N>
@@ -787,7 +799,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     let mut filename = String::new();
                     let mut in_filename_quote = false;
                     let mut filename_quote_char = ' ';
-                    
+
                     while let Some(&ch) = chars.peek() {
                         if !in_filename_quote && (ch == '"' || ch == '\'') {
                             in_filename_quote = true;
@@ -796,8 +808,15 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         } else if in_filename_quote && ch == filename_quote_char {
                             in_filename_quote = false;
                             chars.next(); // consume quote but don't add to filename
-                        } else if !in_filename_quote && (ch == ' ' || ch == '\t' || ch == '\n'
-                            || ch == ';' || ch == '|' || ch == '&' || ch == '>' || ch == '<')
+                        } else if !in_filename_quote
+                            && (ch == ' '
+                                || ch == '\t'
+                                || ch == '\n'
+                                || ch == ';'
+                                || ch == '|'
+                                || ch == '&'
+                                || ch == '>'
+                                || ch == '<')
                         {
                             break;
                         } else {
@@ -815,9 +834,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         }
                     } else {
                         // No filename provided - error
-                        return Err(
-                            "Invalid redirection: expected filename after >".to_string()
-                        );
+                        return Err("Invalid redirection: expected filename after >".to_string());
                     }
                 }
             }
@@ -967,7 +984,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     let mut filename = String::new();
                     let mut in_filename_quote = false;
                     let mut filename_quote_char = ' ';
-                    
+
                     while let Some(&ch) = chars.peek() {
                         if !in_filename_quote && (ch == '"' || ch == '\'') {
                             in_filename_quote = true;
@@ -976,8 +993,15 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         } else if in_filename_quote && ch == filename_quote_char {
                             in_filename_quote = false;
                             chars.next(); // consume quote but don't add to filename
-                        } else if !in_filename_quote && (ch == ' ' || ch == '\t' || ch == '\n'
-                            || ch == ';' || ch == '|' || ch == '&' || ch == '>' || ch == '<')
+                        } else if !in_filename_quote
+                            && (ch == ' '
+                                || ch == '\t'
+                                || ch == '\n'
+                                || ch == ';'
+                                || ch == '|'
+                                || ch == '&'
+                                || ch == '>'
+                                || ch == '<')
                         {
                             break;
                         } else {
@@ -1000,7 +1024,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     let mut filename = String::new();
                     let mut in_filename_quote = false;
                     let mut filename_quote_char = ' ';
-                    
+
                     while let Some(&ch) = chars.peek() {
                         if !in_filename_quote && (ch == '"' || ch == '\'') {
                             in_filename_quote = true;
@@ -1009,8 +1033,15 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         } else if in_filename_quote && ch == filename_quote_char {
                             in_filename_quote = false;
                             chars.next(); // consume quote but don't add to filename
-                        } else if !in_filename_quote && (ch == ' ' || ch == '\t' || ch == '\n'
-                            || ch == ';' || ch == '|' || ch == '&' || ch == '>' || ch == '<')
+                        } else if !in_filename_quote
+                            && (ch == ' '
+                                || ch == '\t'
+                                || ch == '\n'
+                                || ch == ';'
+                                || ch == '|'
+                                || ch == '&'
+                                || ch == '>'
+                                || ch == '<')
                         {
                             break;
                         } else {
@@ -1028,9 +1059,7 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                         }
                     } else {
                         // No filename provided - error
-                        return Err(
-                            "Invalid redirection: expected filename after <".to_string()
-                        );
+                        return Err("Invalid redirection: expected filename after <".to_string());
                     }
                 }
             }
@@ -1084,20 +1113,18 @@ pub fn lex(input: &str, shell_state: &ShellState) -> Result<Vec<Token>, String> 
                     let mut check_chars = brace_content.chars().peekable();
                     let mut check_in_single = false;
                     let mut check_in_double = false;
-                    
+
                     while let Some(ch) = check_chars.next() {
                         if ch == '\'' && !check_in_double {
                             check_in_single = !check_in_single;
                         } else if ch == '"' && !check_in_single {
                             check_in_double = !check_in_double;
-                        } else if !check_in_single && !check_in_double {
-                            if ch == ',' {
-                                has_brace_expansion_pattern = true;
-                                break;
-                            } else if ch == '.' && check_chars.peek() == Some(&'.') {
-                                has_brace_expansion_pattern = true;
-                                break;
-                            }
+                        } else if !check_in_single
+                            && !check_in_double
+                            && (ch == ',' || (ch == '.' && check_chars.peek() == Some(&'.')))
+                        {
+                            has_brace_expansion_pattern = true;
+                            break;
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,18 +212,16 @@ fn main() {
                                     shell_state.collecting_heredoc =
                                         Some((command_line, delimiter, content));
                                 }
+                            } else if line.trim() == delimiter.trim() {
+                                shell_state.pending_heredoc_content = Some(content);
+                                script_engine::execute_line(&command_line, &mut shell_state);
                             } else {
-                                if line.trim() == delimiter.trim() {
-                                    shell_state.pending_heredoc_content = Some(content);
-                                    script_engine::execute_line(&command_line, &mut shell_state);
-                                } else {
-                                    if !content.is_empty() {
-                                        content.push('\n');
-                                    }
-                                    content.push_str(&line);
-                                    shell_state.collecting_heredoc =
-                                        Some((command_line, delimiter, content));
+                                if !content.is_empty() {
+                                    content.push('\n');
                                 }
+                                content.push_str(&line);
+                                shell_state.collecting_heredoc =
+                                    Some((command_line, delimiter, content));
                             }
                         } else {
                             // Normal line processing
@@ -374,10 +372,10 @@ fn execute_exit_trap(shell_state: &mut state::ShellState) {
 fn source_rushrc(shell_state: &mut state::ShellState) {
     if let Some(home) = env::var_os("HOME") {
         let rushrc_path = std::path::Path::new(&home).join(".rushrc");
-        if rushrc_path.exists() {
-            if let Ok(content) = fs::read_to_string(rushrc_path) {
-                script_engine::execute_script(&content, shell_state, Some(&SHUTDOWN));
-            }
+        if rushrc_path.exists()
+            && let Ok(content) = fs::read_to_string(rushrc_path)
+        {
+            script_engine::execute_script(&content, shell_state, Some(&SHUTDOWN));
         }
     }
 }
@@ -390,16 +388,16 @@ mod tests {
     #[test]
     fn test_noexec_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noexec
         shell_state.options.noexec = true;
-        
+
         // This command would normally set a variable, but with noexec it shouldn't
         script_engine::execute_line("TEST_VAR=should_not_be_set", &mut shell_state);
-        
+
         // Variable should not be set because command wasn't executed
         assert_eq!(shell_state.get_var("TEST_VAR"), None);
-        
+
         // Exit code should still be 0 (success)
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -409,7 +407,7 @@ mod tests {
     fn test_noexec_complex() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.noexec = true;
-        
+
         // Create unique temp file path
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -417,13 +415,16 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/test_noexec_{}.txt", timestamp);
-        
+
         // Complex command with pipes and redirections
-        script_engine::execute_line(&format!("echo hello | cat > {}", temp_file), &mut shell_state);
-        
+        script_engine::execute_line(
+            &format!("echo hello | cat > {}", temp_file),
+            &mut shell_state,
+        );
+
         // File should not be created
         assert!(!std::path::Path::new(&temp_file).exists());
-        
+
         // Exit code should be 0
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -432,17 +433,17 @@ mod tests {
     #[test]
     fn test_xtrace_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable xtrace
         shell_state.options.xtrace = true;
-        
+
         // Set a test variable
         shell_state.set_var("TEST_VAR", "test_value".to_string());
-        
+
         // Execute a command - it should print trace output
         // We can't easily capture stderr in this test, but we can verify the command executes
         script_engine::execute_line("echo $TEST_VAR", &mut shell_state);
-        
+
         // Command should execute normally
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -462,14 +463,14 @@ mod tests {
     #[test]
     fn test_xtrace_with_ps4() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set custom PS4
         shell_state.set_var("PS4", "DEBUG: ".to_string());
         shell_state.options.xtrace = true;
-        
+
         // Execute command
         script_engine::execute_line("echo test", &mut shell_state);
-        
+
         // Verify PS4 is set correctly
         assert_eq!(shell_state.get_var("PS4"), Some("DEBUG: ".to_string()));
         assert_eq!(shell_state.last_exit_code, 0);
@@ -479,19 +480,19 @@ mod tests {
     #[test]
     fn test_nounset_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable nounset
         shell_state.options.nounset = true;
-        
+
         // Note: The lexer fix means ${UNSET_VAR} is no longer expanded during lexing.
         // However, the executor doesn't yet handle ${...} syntax expansion.
         // For now, skip this test as it requires executor changes.
         // TODO: Re-enable once executor handles ${...} syntax with nounset checking
-        
+
         // Temporarily test with simple $VAR syntax which IS handled by executor
         // but doesn't trigger nounset (by design - only ${VAR} triggers nounset)
         script_engine::execute_line("TEST=$UNSET_VAR", &mut shell_state);
-        
+
         // Simple $VAR syntax doesn't trigger nounset, so this succeeds
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -501,13 +502,13 @@ mod tests {
     fn test_nounset_with_set_variable() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Set a variable
         shell_state.set_var("SET_VAR", "value".to_string());
-        
+
         // Should work fine with set variable
         script_engine::execute_line("echo ${SET_VAR}", &mut shell_state);
-        
+
         // Should succeed
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -517,10 +518,10 @@ mod tests {
     fn test_nounset_with_default() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Using default expansion should work even with unset variable
         script_engine::execute_line("echo ${UNSET_VAR:-default}", &mut shell_state);
-        
+
         // Should succeed because we provided a default
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -529,13 +530,13 @@ mod tests {
     #[test]
     fn test_errexit_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable errexit
         shell_state.options.errexit = true;
-        
+
         // Execute a command that fails
         script_engine::execute_line("false", &mut shell_state);
-        
+
         // exit_requested should be set
         assert!(shell_state.exit_requested);
         assert_ne!(shell_state.exit_code, 0);
@@ -546,10 +547,10 @@ mod tests {
     fn test_errexit_success() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Execute a successful command
         script_engine::execute_line("true", &mut shell_state);
-        
+
         // exit_requested should NOT be set
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -560,10 +561,13 @@ mod tests {
     fn test_errexit_in_conditional() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // False in if condition should not trigger errexit
-        script_engine::execute_line("if false; then echo fail; else echo pass; fi", &mut shell_state);
-        
+        script_engine::execute_line(
+            "if false; then echo fail; else echo pass; fi",
+            &mut shell_state,
+        );
+
         // Should not exit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -573,18 +577,18 @@ mod tests {
     #[test]
     fn test_multiple_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable multiple options
         shell_state.options.xtrace = true;
         shell_state.options.nounset = true;
-        
+
         // Set a variable
         shell_state.set_var("TEST", "value".to_string());
-        
+
         // Test with simple $VAR syntax (which IS expanded by executor)
         script_engine::execute_line("echo $TEST", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 0);
-        
+
         // Note: ${...} syntax is not yet expanded by executor after lexer fix
         // TODO: Update test once executor handles ${...} syntax
         script_engine::execute_line("TEST2=$UNSET", &mut shell_state);
@@ -596,25 +600,25 @@ mod tests {
     #[test]
     fn test_set_builtin_enable_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Initially all options should be off
         assert!(!shell_state.options.errexit);
         assert!(!shell_state.options.nounset);
         assert!(!shell_state.options.xtrace);
         assert!(!shell_state.options.noexec);
-        
+
         // Enable errexit with -e
         script_engine::execute_line("set -e", &mut shell_state);
         assert!(shell_state.options.errexit);
-        
+
         // Enable nounset with -u
         script_engine::execute_line("set -u", &mut shell_state);
         assert!(shell_state.options.nounset);
-        
+
         // Enable xtrace with -x
         script_engine::execute_line("set -x", &mut shell_state);
         assert!(shell_state.options.xtrace);
-        
+
         // Enable noexec with -n
         script_engine::execute_line("set -n", &mut shell_state);
         assert!(shell_state.options.noexec);
@@ -643,25 +647,25 @@ mod tests {
     #[test]
     fn test_set_builtin_disable_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable all options first
         shell_state.options.errexit = true;
         shell_state.options.nounset = true;
         shell_state.options.xtrace = true;
         shell_state.options.noexec = true;
-        
+
         // Disable errexit with +e
         script_engine::execute_line("set +e", &mut shell_state);
         assert!(!shell_state.options.errexit);
-        
+
         // Disable nounset with +u
         script_engine::execute_line("set +u", &mut shell_state);
         assert!(!shell_state.options.nounset);
-        
+
         // Disable xtrace with +x
         script_engine::execute_line("set +x", &mut shell_state);
         assert!(!shell_state.options.xtrace);
-        
+
         // Disable noexec with +n
         script_engine::execute_line("set +n", &mut shell_state);
         assert!(!shell_state.options.noexec);
@@ -671,30 +675,30 @@ mod tests {
     #[test]
     fn test_set_builtin_long_names() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable with long names
         script_engine::execute_line("set -o errexit", &mut shell_state);
         assert!(shell_state.options.errexit);
-        
+
         script_engine::execute_line("set -o nounset", &mut shell_state);
         assert!(shell_state.options.nounset);
-        
+
         script_engine::execute_line("set -o xtrace", &mut shell_state);
         assert!(shell_state.options.xtrace);
-        
+
         script_engine::execute_line("set -o noexec", &mut shell_state);
         assert!(shell_state.options.noexec);
-        
+
         // Disable with long names
         script_engine::execute_line("set +o errexit", &mut shell_state);
         assert!(!shell_state.options.errexit);
-        
+
         script_engine::execute_line("set +o nounset", &mut shell_state);
         assert!(!shell_state.options.nounset);
-        
+
         script_engine::execute_line("set +o xtrace", &mut shell_state);
         assert!(!shell_state.options.xtrace);
-        
+
         script_engine::execute_line("set +o noexec", &mut shell_state);
         assert!(!shell_state.options.noexec);
     }
@@ -704,16 +708,16 @@ mod tests {
     fn test_errexit_sequence() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Set a marker variable
         shell_state.set_var("MARKER", "initial".to_string());
-        
+
         // Execute sequence where first command fails
         script_engine::execute_line("false; MARKER=should_not_set", &mut shell_state);
-        
+
         // exit_requested should be set after false
         assert!(shell_state.exit_requested);
-        
+
         // MARKER should still be "initial" because second command shouldn't execute
         assert_eq!(shell_state.get_var("MARKER"), Some("initial".to_string()));
     }
@@ -723,10 +727,10 @@ mod tests {
     fn test_noexec_parse_errors() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.noexec = true;
-        
+
         // Invalid syntax should still be caught
         script_engine::execute_line("if then fi", &mut shell_state);
-        
+
         // Should have error (parse error)
         // The exact behavior depends on error handling, but it shouldn't crash
     }
@@ -736,13 +740,13 @@ mod tests {
     fn test_xtrace_variable_expansion() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.xtrace = true;
-        
+
         shell_state.set_var("VAR1", "value1".to_string());
         shell_state.set_var("VAR2", "value2".to_string());
-        
+
         // Execute command with variables - trace should show expanded values
         script_engine::execute_line("echo $VAR1 $VAR2", &mut shell_state);
-        
+
         assert_eq!(shell_state.last_exit_code, 0);
     }
 
@@ -751,14 +755,14 @@ mod tests {
     fn test_nounset_positional_params() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Set positional parameters
         shell_state.set_positional_params(vec!["arg1".to_string(), "arg2".to_string()]);
-        
+
         // Should work with set positional parameters
         script_engine::execute_line("echo $1 $2", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 0);
-        
+
         // Accessing unset positional parameter should work (they expand to empty)
         script_engine::execute_line("echo $99", &mut shell_state);
         // Positional parameters that don't exist expand to empty, not error
@@ -770,11 +774,11 @@ mod tests {
     fn test_nounset_error_message_format() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Note: ${...} syntax not yet expanded by executor after lexer fix
         // TODO: Update test once executor handles ${...} syntax with nounset
         script_engine::execute_line("echo $UNSET_VAR", &mut shell_state);
-        
+
         // Simple $VAR doesn't trigger nounset
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -784,11 +788,11 @@ mod tests {
     fn test_nounset_with_substring_expansion() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Substring expansion on unset variable should not trigger nounset
         // because it has a modifier
         script_engine::execute_line("echo ${UNSET_VAR:0:5}", &mut shell_state);
-        
+
         // Should succeed (substring returns empty string for unset vars)
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -798,11 +802,11 @@ mod tests {
     fn test_nounset_in_subshell() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Note: ${...} syntax not yet expanded by executor after lexer fix
         // TODO: Update test once executor handles ${...} syntax
         script_engine::execute_line("(echo $UNSET_VAR)", &mut shell_state);
-        
+
         // Simple $VAR doesn't trigger nounset
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -812,18 +816,18 @@ mod tests {
     fn test_nounset_in_function() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Define function that uses unset variable - definition should succeed
         // Note: ${...} syntax not yet expanded by executor after lexer fix
         script_engine::execute_line("test_func() { echo $UNSET_VAR; }", &mut shell_state);
-        
+
         // Function definition should succeed (no error during parsing)
         assert_eq!(shell_state.last_exit_code, 0);
         assert!(!shell_state.exit_requested);
-        
+
         // Call the function
         script_engine::execute_line("test_func", &mut shell_state);
-        
+
         // Simple $VAR doesn't trigger nounset
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -833,38 +837,56 @@ mod tests {
     #[test]
     fn test_nounset_function_definition_deferred() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable nounset
         shell_state.options.nounset = true;
-        
+
         // Define a function that references an unset variable
         // This should SUCCEED because we're only defining, not executing
         script_engine::execute_line("my_func() { echo $UNSET_VAR; }", &mut shell_state);
-        
+
         // Function definition should succeed (exit code 0)
-        assert_eq!(shell_state.last_exit_code, 0, "Function definition should succeed even with unset variable in body");
-        
+        assert_eq!(
+            shell_state.last_exit_code, 0,
+            "Function definition should succeed even with unset variable in body"
+        );
+
         // Verify the function was actually defined
-        assert!(shell_state.get_function("my_func").is_some(), "Function should be defined");
-        
+        assert!(
+            shell_state.get_function("my_func").is_some(),
+            "Function should be defined"
+        );
+
         // Verify nounset is still enabled
-        assert!(shell_state.options.nounset, "nounset option should still be enabled");
-        
+        assert!(
+            shell_state.options.nounset,
+            "nounset option should still be enabled"
+        );
+
         // Now when we CALL the function, it should execute without error
         // (because simple $VAR syntax doesn't trigger nounset - only ${VAR} does)
         script_engine::execute_line("my_func", &mut shell_state);
-        
+
         // Simple $VAR doesn't trigger nounset, so this succeeds
-        assert_eq!(shell_state.last_exit_code, 0, "Function call should succeed (simple $VAR doesn't trigger nounset)");
-        
+        assert_eq!(
+            shell_state.last_exit_code, 0,
+            "Function call should succeed (simple $VAR doesn't trigger nounset)"
+        );
+
         // Test with ${{...}} syntax which SHOULD trigger nounset when called
         // Define another function with ${{...}} syntax
         script_engine::execute_line("my_func2() { echo ${UNSET_VAR2}; }", &mut shell_state);
-        
+
         // Function definition should still succeed
-        assert_eq!(shell_state.last_exit_code, 0, "Function definition with dollar-brace should succeed");
-        assert!(shell_state.get_function("my_func2").is_some(), "Function my_func2 should be defined");
-        
+        assert_eq!(
+            shell_state.last_exit_code, 0,
+            "Function definition with dollar-brace should succeed"
+        );
+        assert!(
+            shell_state.get_function("my_func2").is_some(),
+            "Function my_func2 should be defined"
+        );
+
         // TODO: Uncomment when executor properly handles ${...} syntax with nounset during execution
         // script_engine::execute_line("my_func2", &mut shell_state);
         // assert_ne!(shell_state.last_exit_code, 0, "Function call should fail with nounset error for ${...} syntax");
@@ -875,10 +897,10 @@ mod tests {
     fn test_nounset_simple_dollar_syntax() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.nounset = true;
-        
+
         // Simple $VAR syntax should still work (expands to empty or literal)
         script_engine::execute_line("echo $UNSET_VAR", &mut shell_state);
-        
+
         // Should succeed (simple $VAR doesn't trigger nounset)
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -888,10 +910,10 @@ mod tests {
     fn test_errexit_with_and_operator() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // false in && chain should not trigger errexit
         script_engine::execute_line("false && echo should_not_print", &mut shell_state);
-        
+
         // Should not exit because && handles the failure
         assert!(!shell_state.exit_requested);
     }
@@ -911,10 +933,10 @@ mod tests {
     fn test_errexit_with_or_operator() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // false in || chain should not trigger errexit
         script_engine::execute_line("false || echo fallback", &mut shell_state);
-        
+
         // Should not exit because || handles the failure
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -926,11 +948,11 @@ mod tests {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
         shell_state.options.nounset = true;
-        
+
         // Note: ${...} syntax not yet expanded by executor after lexer fix
         // TODO: Update test once executor handles ${...} syntax
         script_engine::execute_line("TEST=$UNSET_VAR", &mut shell_state);
-        
+
         // Simple $VAR doesn't trigger nounset
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -941,11 +963,11 @@ mod tests {
         let mut shell_state = state::ShellState::new();
         shell_state.options.xtrace = true;
         shell_state.options.noexec = true;
-        
+
         // Should print trace but not execute
         shell_state.set_var("TEST", "initial".to_string());
         script_engine::execute_line("TEST=modified", &mut shell_state);
-        
+
         // Variable should not be modified due to noexec
         assert_eq!(shell_state.get_var("TEST"), Some("initial".to_string()));
     }
@@ -957,10 +979,10 @@ mod tests {
     #[test]
     fn test_positional_params_set_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set positional parameters using set --
         script_engine::execute_line("set -- arg1 arg2 arg3", &mut shell_state);
-        
+
         assert_eq!(shell_state.get_var("1"), Some("arg1".to_string()));
         assert_eq!(shell_state.get_var("2"), Some("arg2".to_string()));
         assert_eq!(shell_state.get_var("3"), Some("arg3".to_string()));
@@ -972,14 +994,14 @@ mod tests {
     #[test]
     fn test_positional_params_clear() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set initial parameters
         shell_state.set_positional_params(vec!["old1".to_string(), "old2".to_string()]);
         assert_eq!(shell_state.get_var("1"), Some("old1".to_string()));
-        
+
         // Clear with set --
         script_engine::execute_line("set --", &mut shell_state);
-        
+
         assert_eq!(shell_state.get_var("1"), None);
         assert_eq!(shell_state.get_var("#"), Some("0".to_string()));
     }
@@ -987,10 +1009,10 @@ mod tests {
     #[test]
     fn test_positional_params_with_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Combine options with positional parameters
         script_engine::execute_line("set -e -- arg1 arg2", &mut shell_state);
-        
+
         assert!(shell_state.options.errexit);
         assert_eq!(shell_state.get_var("1"), Some("arg1".to_string()));
         assert_eq!(shell_state.get_var("2"), Some("arg2".to_string()));
@@ -999,13 +1021,13 @@ mod tests {
     #[test]
     fn test_positional_params_in_command() {
         let mut shell_state = state::ShellState::new();
-        
+
         shell_state.set_positional_params(vec!["hello".to_string(), "world".to_string()]);
-        
+
         // Use positional parameters in echo command
         script_engine::execute_line("TEST=$1", &mut shell_state);
         assert_eq!(shell_state.get_var("TEST"), Some("hello".to_string()));
-        
+
         script_engine::execute_line("TEST=$2", &mut shell_state);
         assert_eq!(shell_state.get_var("TEST"), Some("world".to_string()));
     }
@@ -1013,9 +1035,9 @@ mod tests {
     #[test]
     fn test_positional_params_dollar_at() {
         let mut shell_state = state::ShellState::new();
-        
+
         shell_state.set_positional_params(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
-        
+
         // $@ should expand to all parameters
         assert_eq!(shell_state.get_var("@"), Some("a b c".to_string()));
     }
@@ -1023,9 +1045,9 @@ mod tests {
     #[test]
     fn test_positional_params_dollar_star() {
         let mut shell_state = state::ShellState::new();
-        
+
         shell_state.set_positional_params(vec!["x".to_string(), "y".to_string()]);
-        
+
         // $* should expand to all parameters
         assert_eq!(shell_state.get_var("*"), Some("x y".to_string()));
     }
@@ -1033,9 +1055,14 @@ mod tests {
     #[test]
     fn test_positional_params_dollar_hash() {
         let mut shell_state = state::ShellState::new();
-        
-        shell_state.set_positional_params(vec!["1".to_string(), "2".to_string(), "3".to_string(), "4".to_string()]);
-        
+
+        shell_state.set_positional_params(vec![
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+        ]);
+
         // $# should return count
         assert_eq!(shell_state.get_var("#"), Some("4".to_string()));
     }
@@ -1056,7 +1083,7 @@ mod tests {
     #[test]
     fn test_positional_params_empty() {
         let shell_state = state::ShellState::new();
-        
+
         // No positional parameters set
         assert_eq!(shell_state.get_var("1"), None);
         assert_eq!(shell_state.get_var("#"), Some("0".to_string()));
@@ -1067,11 +1094,11 @@ mod tests {
     #[test]
     fn test_positional_params_replace() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set initial parameters
         script_engine::execute_line("set -- old1 old2", &mut shell_state);
         assert_eq!(shell_state.get_var("1"), Some("old1".to_string()));
-        
+
         // Replace with new parameters
         script_engine::execute_line("set -- new1 new2 new3", &mut shell_state);
         assert_eq!(shell_state.get_var("1"), Some("new1".to_string()));
@@ -1087,11 +1114,11 @@ mod tests {
     #[test]
     fn test_verbose_option_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable verbose
         script_engine::execute_line("set -v", &mut shell_state);
         assert!(shell_state.options.verbose);
-        
+
         // Execute a command - it should print the line (we can't capture stderr easily)
         script_engine::execute_line("echo test", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -1100,21 +1127,21 @@ mod tests {
     #[test]
     fn test_verbose_option_disable() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable then disable
         shell_state.options.verbose = true;
         script_engine::execute_line("set +v", &mut shell_state);
-        
+
         assert!(!shell_state.options.verbose);
     }
 
     #[test]
     fn test_verbose_with_long_name() {
         let mut shell_state = state::ShellState::new();
-        
+
         script_engine::execute_line("set -o verbose", &mut shell_state);
         assert!(shell_state.options.verbose);
-        
+
         script_engine::execute_line("set +o verbose", &mut shell_state);
         assert!(!shell_state.options.verbose);
     }
@@ -1126,11 +1153,11 @@ mod tests {
     #[test]
     fn test_noglob_option_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noglob
         script_engine::execute_line("set -f", &mut shell_state);
         assert!(shell_state.options.noglob);
-        
+
         // Wildcards should not expand
         script_engine::execute_line("TEST='*.txt'", &mut shell_state);
         assert_eq!(shell_state.get_var("TEST"), Some("*.txt".to_string()));
@@ -1139,20 +1166,20 @@ mod tests {
     #[test]
     fn test_noglob_option_disable() {
         let mut shell_state = state::ShellState::new();
-        
+
         shell_state.options.noglob = true;
         script_engine::execute_line("set +f", &mut shell_state);
-        
+
         assert!(!shell_state.options.noglob);
     }
 
     #[test]
     fn test_noglob_with_long_name() {
         let mut shell_state = state::ShellState::new();
-        
+
         script_engine::execute_line("set -o noglob", &mut shell_state);
         assert!(shell_state.options.noglob);
-        
+
         script_engine::execute_line("set +o noglob", &mut shell_state);
         assert!(!shell_state.options.noglob);
     }
@@ -1164,7 +1191,7 @@ mod tests {
     #[test]
     fn test_noclobber_option_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
         assert!(shell_state.options.noclobber);
@@ -1175,10 +1202,10 @@ mod tests {
         use std::sync::Mutex;
         static TEST_LOCK: Mutex<()> = Mutex::new(());
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         let mut shell_state = state::ShellState::new();
         shell_state.options.noclobber = true;
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1186,20 +1213,20 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_noclobber_{}.txt", timestamp);
-        
+
         // Create file first
         std::fs::write(&temp_file, "original").unwrap();
-        
+
         // Try to overwrite with > should fail
         script_engine::execute_line(&format!("echo new > {}", temp_file), &mut shell_state);
-        
+
         // Should have error
         assert_ne!(shell_state.last_exit_code, 0);
-        
+
         // File should still have original content
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content, "original");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1209,10 +1236,10 @@ mod tests {
         use std::sync::Mutex;
         static TEST_LOCK: Mutex<()> = Mutex::new(());
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         let mut shell_state = state::ShellState::new();
         shell_state.options.noclobber = true;
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1220,16 +1247,16 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_noclobber_append_{}.txt", timestamp);
-        
+
         // Create file
         std::fs::write(&temp_file, "line1\n").unwrap();
-        
+
         // Append with >> should work
         script_engine::execute_line(&format!("echo line2 >> {}", temp_file), &mut shell_state);
-        
+
         // Should succeed
         assert_eq!(shell_state.last_exit_code, 0);
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1237,10 +1264,10 @@ mod tests {
     #[test]
     fn test_noclobber_with_long_name() {
         let mut shell_state = state::ShellState::new();
-        
+
         script_engine::execute_line("set -o noclobber", &mut shell_state);
         assert!(shell_state.options.noclobber);
-        
+
         script_engine::execute_line("set +o noclobber", &mut shell_state);
         assert!(!shell_state.options.noclobber);
     }
@@ -1250,7 +1277,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1258,19 +1285,22 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_clobber_no_noclobber_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Create initial file
         std::fs::write(&temp_file, "initial content\n").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
-        
+
         // Test >| without noclobber (should work like >)
-        script_engine::execute_line(&format!("echo 'overwritten' >| {}", temp_file), &mut shell_state);
-        
+        script_engine::execute_line(
+            &format!("echo 'overwritten' >| {}", temp_file),
+            &mut shell_state,
+        );
+
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "overwritten");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1280,7 +1310,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1288,23 +1318,26 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_clobber_with_noclobber_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
         assert!(shell_state.options.noclobber);
-        
+
         // Create initial file
         std::fs::write(&temp_file, "initial content\n").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
-        
+
         // Test >| with noclobber (should override and allow overwrite)
-        script_engine::execute_line(&format!("echo 'overwritten with clobber' >| {}", temp_file), &mut shell_state);
-        
+        script_engine::execute_line(
+            &format!("echo 'overwritten with clobber' >| {}", temp_file),
+            &mut shell_state,
+        );
+
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "overwritten with clobber");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1314,7 +1347,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file path (file doesn't exist yet)
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1322,19 +1355,22 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_clobber_new_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
-        
+
         // Test >| creating new file (should work)
-        script_engine::execute_line(&format!("echo 'new file' >| {}", temp_file), &mut shell_state);
-        
+        script_engine::execute_line(
+            &format!("echo 'new file' >| {}", temp_file),
+            &mut shell_state,
+        );
+
         assert!(std::path::Path::new(&temp_file).exists());
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "new file");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1344,7 +1380,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1352,23 +1388,26 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_regular_noclobber_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
-        
+
         // Create initial file
         std::fs::write(&temp_file, "initial content\n").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
-        
+
         // Test > with noclobber (should fail)
-        script_engine::execute_line(&format!("echo 'should fail' > {}", temp_file), &mut shell_state);
-        
+        script_engine::execute_line(
+            &format!("echo 'should fail' > {}", temp_file),
+            &mut shell_state,
+        );
+
         // File should still have original content
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "initial content");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1378,7 +1417,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1386,23 +1425,23 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_clobber_var_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
         shell_state.set_var("OUTFILE", temp_file.clone());
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
-        
+
         // Create initial file
         std::fs::write(&temp_file, "initial\n").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
-        
+
         // Test >| with variable expansion
         script_engine::execute_line("echo 'expanded' >| $OUTFILE", &mut shell_state);
-        
+
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "expanded");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1412,7 +1451,7 @@ mod tests {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _lock = ENV_LOCK.lock().unwrap();
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1420,25 +1459,25 @@ mod tests {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_clobber_multi_{}.txt", timestamp);
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable noclobber
         script_engine::execute_line("set -C", &mut shell_state);
-        
+
         // Create initial file
         std::fs::write(&temp_file, "first\n").unwrap();
         std::thread::sleep(std::time::Duration::from_millis(10));
-        
+
         // Overwrite multiple times with >|
         script_engine::execute_line(&format!("echo 'second' >| {}", temp_file), &mut shell_state);
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "second");
-        
+
         script_engine::execute_line(&format!("echo 'third' >| {}", temp_file), &mut shell_state);
         let content = std::fs::read_to_string(&temp_file).unwrap();
         assert_eq!(content.trim(), "third");
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1450,7 +1489,7 @@ mod tests {
     #[test]
     fn test_allexport_option_basic() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable allexport
         script_engine::execute_line("set -a", &mut shell_state);
         assert!(shell_state.options.allexport);
@@ -1471,10 +1510,10 @@ mod tests {
     fn test_allexport_auto_exports() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.allexport = true;
-        
+
         // Set a variable
         script_engine::execute_line("TEST_VAR=value", &mut shell_state);
-        
+
         // Should be automatically exported
         assert!(shell_state.exported.contains("TEST_VAR"));
         assert_eq!(shell_state.get_var("TEST_VAR"), Some("value".to_string()));
@@ -1484,12 +1523,12 @@ mod tests {
     fn test_allexport_multiple_variables() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.allexport = true;
-        
+
         // Set multiple variables
         script_engine::execute_line("VAR1=val1", &mut shell_state);
         script_engine::execute_line("VAR2=val2", &mut shell_state);
         script_engine::execute_line("VAR3=val3", &mut shell_state);
-        
+
         // All should be exported
         assert!(shell_state.exported.contains("VAR1"));
         assert!(shell_state.exported.contains("VAR2"));
@@ -1499,16 +1538,16 @@ mod tests {
     #[test]
     fn test_allexport_disable() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable allexport
         shell_state.options.allexport = true;
         script_engine::execute_line("VAR1=exported", &mut shell_state);
         assert!(shell_state.exported.contains("VAR1"));
-        
+
         // Disable allexport
         script_engine::execute_line("set +a", &mut shell_state);
         assert!(!shell_state.options.allexport);
-        
+
         // New variables should not be exported
         script_engine::execute_line("VAR2=not_exported", &mut shell_state);
         assert!(!shell_state.exported.contains("VAR2"));
@@ -1517,10 +1556,10 @@ mod tests {
     #[test]
     fn test_allexport_with_long_name() {
         let mut shell_state = state::ShellState::new();
-        
+
         script_engine::execute_line("set -o allexport", &mut shell_state);
         assert!(shell_state.options.allexport);
-        
+
         script_engine::execute_line("set +o allexport", &mut shell_state);
         assert!(!shell_state.options.allexport);
     }
@@ -1532,10 +1571,10 @@ mod tests {
     #[test]
     fn test_multiple_new_options_together() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable multiple options at once
         script_engine::execute_line("set -vfCa", &mut shell_state);
-        
+
         assert!(shell_state.options.verbose);
         assert!(shell_state.options.noglob);
         assert!(shell_state.options.noclobber);
@@ -1545,10 +1584,10 @@ mod tests {
     #[test]
     fn test_all_options_combined() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable all options
         script_engine::execute_line("set -euxvnfCa", &mut shell_state);
-        
+
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
         assert!(shell_state.options.xtrace);
@@ -1562,10 +1601,10 @@ mod tests {
     #[test]
     fn test_option_combination_with_positional_params() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Combine options with positional parameters
         script_engine::execute_line("set -vf -- arg1 arg2", &mut shell_state);
-        
+
         assert!(shell_state.options.verbose);
         assert!(shell_state.options.noglob);
         assert_eq!(shell_state.get_var("1"), Some("arg1".to_string()));
@@ -1586,7 +1625,7 @@ mod set_builtin_edge_cases {
     fn test_set_no_arguments() {
         let mut shell_state = state::ShellState::new();
         shell_state.set_var("TEST_VAR", "test_value".to_string());
-        
+
         // set with no args should succeed (displays variables)
         script_engine::execute_line("set", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -1596,10 +1635,10 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_invalid_option_combination() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try to set an invalid option
         script_engine::execute_line("set -Z", &mut shell_state);
-        
+
         // Should fail with non-zero exit code
         assert_ne!(shell_state.last_exit_code, 0);
     }
@@ -1608,16 +1647,16 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_option_precedence_last_wins() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable then disable in same command
         script_engine::execute_line("set -e +e", &mut shell_state);
-        
+
         // Last option should win (disabled)
         assert!(!shell_state.options.errexit);
-        
+
         // Reverse order
         script_engine::execute_line("set +e -e", &mut shell_state);
-        
+
         // Last option should win (enabled)
         assert!(shell_state.options.errexit);
     }
@@ -1626,16 +1665,16 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_mixing_short_and_long_names() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Mix short and long names
         script_engine::execute_line("set -e -o nounset", &mut shell_state);
-        
+
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
-        
+
         // Disable with mixed syntax
         script_engine::execute_line("set +e +o nounset", &mut shell_state);
-        
+
         assert!(!shell_state.options.errexit);
         assert!(!shell_state.options.nounset);
     }
@@ -1644,10 +1683,10 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_unicode_in_positional_params() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set positional parameters with Unicode
         script_engine::execute_line("set -- 你好 мир 🚀", &mut shell_state);
-        
+
         assert_eq!(shell_state.get_var("1"), Some("你好".to_string()));
         assert_eq!(shell_state.get_var("2"), Some("мир".to_string()));
         assert_eq!(shell_state.get_var("3"), Some("🚀".to_string()));
@@ -1658,15 +1697,15 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_large_positional_param_list() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Create a command with 100 positional parameters
         let mut cmd = "set --".to_string();
         for i in 1..=100 {
             cmd.push_str(&format!(" arg{}", i));
         }
-        
+
         script_engine::execute_line(&cmd, &mut shell_state);
-        
+
         // Verify first, middle, and last parameters
         assert_eq!(shell_state.get_var("1"), Some("arg1".to_string()));
         assert_eq!(shell_state.get_var("50"), Some("arg50".to_string()));
@@ -1678,17 +1717,17 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_nested_option_changes() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable errexit
         script_engine::execute_line("set -e", &mut shell_state);
         assert!(shell_state.options.errexit);
-        
+
         // Define a function that disables errexit
         script_engine::execute_line("func() { set +e; }", &mut shell_state);
-        
+
         // Call the function
         script_engine::execute_line("func", &mut shell_state);
-        
+
         // errexit should be disabled after function call
         assert!(!shell_state.options.errexit);
     }
@@ -1697,13 +1736,13 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_options_in_subshells() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set option in parent
         shell_state.options.errexit = false;
-        
+
         // Subshell should inherit options
         script_engine::execute_line("(set -e; false)", &mut shell_state);
-        
+
         // Parent shell's errexit should still be disabled
         assert!(!shell_state.options.errexit);
     }
@@ -1712,10 +1751,10 @@ mod set_builtin_edge_cases {
     #[test]
     fn test_positional_params_special_chars() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set params with special shell characters
         script_engine::execute_line("set -- '$VAR' '|' '>' '&'", &mut shell_state);
-        
+
         assert_eq!(shell_state.get_var("1"), Some("$VAR".to_string()));
         assert_eq!(shell_state.get_var("2"), Some("|".to_string()));
         assert_eq!(shell_state.get_var("3"), Some(">".to_string()));
@@ -1735,10 +1774,10 @@ mod set_builtin_error_handling {
     #[test]
     fn test_invalid_short_option() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try invalid option -Z
         script_engine::execute_line("set -Z", &mut shell_state);
-        
+
         // Should fail
         assert_ne!(shell_state.last_exit_code, 0);
     }
@@ -1747,10 +1786,10 @@ mod set_builtin_error_handling {
     #[test]
     fn test_invalid_long_option() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try invalid long option
         script_engine::execute_line("set -o invalidoption", &mut shell_state);
-        
+
         // Should fail
         assert_ne!(shell_state.last_exit_code, 0);
     }
@@ -1760,10 +1799,10 @@ mod set_builtin_error_handling {
     fn test_dash_o_without_argument_displays_options() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // -o without argument should display all options (POSIX behavior)
         script_engine::execute_line("set -o", &mut shell_state);
-        
+
         // Should succeed
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -1772,13 +1811,13 @@ mod set_builtin_error_handling {
     #[test]
     fn test_malformed_option_syntax() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try various malformed syntaxes
         script_engine::execute_line("set ---", &mut shell_state);
         assert_ne!(shell_state.last_exit_code, 0);
-        
+
         shell_state.last_exit_code = 0; // Reset
-        
+
         script_engine::execute_line("set -", &mut shell_state);
         // Single dash might be valid (depends on implementation)
     }
@@ -1789,10 +1828,10 @@ mod set_builtin_error_handling {
         use std::sync::Mutex;
         static TEST_LOCK: Mutex<()> = Mutex::new(());
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         let mut shell_state = state::ShellState::new();
         shell_state.options.noclobber = true;
-        
+
         // Create unique temp file
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1800,15 +1839,15 @@ mod set_builtin_error_handling {
             .unwrap()
             .as_nanos();
         let temp_file = format!("/tmp/rush_test_noclobber_perm_{}.txt", timestamp);
-        
+
         // Create file
         std::fs::write(&temp_file, "original").unwrap();
-        
+
         // Try to overwrite should fail
         script_engine::execute_line(&format!("echo new > {}", temp_file), &mut shell_state);
-        
+
         assert_ne!(shell_state.last_exit_code, 0);
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_file);
     }
@@ -1817,10 +1856,10 @@ mod set_builtin_error_handling {
     #[test]
     fn test_multiple_invalid_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try multiple invalid options
         script_engine::execute_line("set -XYZ", &mut shell_state);
-        
+
         // Should fail on first invalid option
         assert_ne!(shell_state.last_exit_code, 0);
     }
@@ -1840,10 +1879,10 @@ mod set_builtin_error_handling {
     #[test]
     fn test_option_with_invalid_value() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Try to set option with value (not supported)
         script_engine::execute_line("set -o errexit=true", &mut shell_state);
-        
+
         // Should fail (options don't take values)
         assert_ne!(shell_state.last_exit_code, 0);
     }
@@ -1863,9 +1902,9 @@ mod set_builtin_integration {
         use std::sync::Mutex;
         static TEST_LOCK: Mutex<()> = Mutex::new(());
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         let mut shell_state = state::ShellState::new();
-        
+
         // Create unique temp script
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
@@ -1873,17 +1912,17 @@ mod set_builtin_integration {
             .unwrap()
             .as_nanos();
         let temp_script = format!("/tmp/rush_test_source_{}.sh", timestamp);
-        
+
         // Write script that sets options
         std::fs::write(&temp_script, "set -e\nset -u\n").unwrap();
-        
+
         // Source the script
         script_engine::execute_line(&format!(". {}", temp_script), &mut shell_state);
-        
+
         // Options should be set in parent shell
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
-        
+
         // Cleanup
         let _ = std::fs::remove_file(&temp_script);
     }
@@ -1892,13 +1931,13 @@ mod set_builtin_integration {
     #[test]
     fn test_options_with_trap_handlers() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set a trap
         script_engine::execute_line("trap 'echo trapped' EXIT", &mut shell_state);
-        
+
         // Enable errexit
         script_engine::execute_line("set -e", &mut shell_state);
-        
+
         // Options should work with traps
         assert!(shell_state.options.errexit);
         assert!(shell_state.get_trap("EXIT").is_some());
@@ -1908,13 +1947,13 @@ mod set_builtin_integration {
     #[test]
     fn test_options_across_functions() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Define function that checks options
         script_engine::execute_line("func() { set -x; }", &mut shell_state);
-        
+
         // Call function
         script_engine::execute_line("func", &mut shell_state);
-        
+
         // Option should persist after function
         assert!(shell_state.options.xtrace);
     }
@@ -1923,13 +1962,13 @@ mod set_builtin_integration {
     #[test]
     fn test_options_with_command_substitution() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable xtrace
         shell_state.options.xtrace = true;
-        
+
         // Command substitution should work with xtrace
         script_engine::execute_line("VAR=$(echo test)", &mut shell_state);
-        
+
         assert_eq!(shell_state.get_var("VAR"), Some("test".to_string()));
         assert!(shell_state.options.xtrace);
     }
@@ -1938,15 +1977,15 @@ mod set_builtin_integration {
     #[test]
     fn test_option_state_preservation() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable multiple options
         script_engine::execute_line("set -eux", &mut shell_state);
-        
+
         // Execute several commands
         script_engine::execute_line("echo test1", &mut shell_state);
         script_engine::execute_line("echo test2", &mut shell_state);
         script_engine::execute_line("echo test3", &mut shell_state);
-        
+
         // Options should still be set
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
@@ -1966,14 +2005,14 @@ mod set_builtin_posix_compliance {
     #[test]
     fn test_set_no_args_shows_variables() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set some variables
         shell_state.set_var("VAR1", "value1".to_string());
         shell_state.set_var("VAR2", "value2".to_string());
-        
+
         // set with no args should succeed
         script_engine::execute_line("set", &mut shell_state);
-        
+
         assert_eq!(shell_state.last_exit_code, 0);
     }
 
@@ -1981,10 +2020,10 @@ mod set_builtin_posix_compliance {
     #[test]
     fn test_set_dash_o_shows_options() {
         let mut shell_state = state::ShellState::new();
-        
+
         // set -o should display all options
         script_engine::execute_line("set -o", &mut shell_state);
-        
+
         assert_eq!(shell_state.last_exit_code, 0);
     }
 
@@ -1992,10 +2031,10 @@ mod set_builtin_posix_compliance {
     #[test]
     fn test_set_plus_o_shows_set_format() {
         let mut shell_state = state::ShellState::new();
-        
+
         // set +o should display options in set format
         script_engine::execute_line("set +o", &mut shell_state);
-        
+
         assert_eq!(shell_state.last_exit_code, 0);
     }
 
@@ -2003,14 +2042,14 @@ mod set_builtin_posix_compliance {
     #[test]
     fn test_option_inheritance_subshells() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set options in parent
         shell_state.options.errexit = true;
         shell_state.options.nounset = true;
-        
+
         // Subshell should inherit options
         script_engine::execute_line("(echo test)", &mut shell_state);
-        
+
         // Parent options should be unchanged
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
@@ -2021,16 +2060,16 @@ mod set_builtin_posix_compliance {
     fn test_errexit_not_in_conditionals() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // False in if condition should not trigger errexit
         script_engine::execute_line("if false; then echo fail; fi", &mut shell_state);
-        
+
         assert!(!shell_state.exit_requested);
-        
+
         // False in while condition should not trigger errexit
         shell_state.exit_requested = false;
         script_engine::execute_line("while false; do echo loop; done", &mut shell_state);
-        
+
         assert!(!shell_state.exit_requested);
     }
 
@@ -2039,10 +2078,10 @@ mod set_builtin_posix_compliance {
     fn test_errexit_pipeline_last_command() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // false in pipeline but last command succeeds
         script_engine::execute_line("false | true", &mut shell_state);
-        
+
         // Should not exit because last command succeeded
         assert!(!shell_state.exit_requested);
     }
@@ -2051,16 +2090,16 @@ mod set_builtin_posix_compliance {
     #[test]
     fn test_posix_special_parameters() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Set positional parameters
         script_engine::execute_line("set -- a b c", &mut shell_state);
-        
+
         // Test $# (count)
         assert_eq!(shell_state.get_var("#"), Some("3".to_string()));
-        
+
         // Test $@ (all params)
         assert_eq!(shell_state.get_var("@"), Some("a b c".to_string()));
-        
+
         // Test $* (all params)
         assert_eq!(shell_state.get_var("*"), Some("a b c".to_string()));
     }
@@ -2096,18 +2135,18 @@ mod set_builtin_performance {
     #[test]
     fn test_large_positional_params() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Create command with 200 parameters
         let mut cmd = "set --".to_string();
         for i in 1..=200 {
             cmd.push_str(&format!(" param{}", i));
         }
-        
+
         script_engine::execute_line(&cmd, &mut shell_state);
-        
+
         // Verify count
         assert_eq!(shell_state.get_var("#"), Some("200".to_string()));
-        
+
         // Verify random access
         assert_eq!(shell_state.get_var("1"), Some("param1".to_string()));
         assert_eq!(shell_state.get_var("100"), Some("param100".to_string()));
@@ -2118,16 +2157,16 @@ mod set_builtin_performance {
     #[test]
     fn test_rapid_option_toggling() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Toggle options rapidly
         for _ in 0..100 {
             script_engine::execute_line("set -e", &mut shell_state);
             assert!(shell_state.options.errexit);
-            
+
             script_engine::execute_line("set +e", &mut shell_state);
             assert!(!shell_state.options.errexit);
         }
-        
+
         // Final state should be consistent
         assert!(!shell_state.options.errexit);
     }
@@ -2136,15 +2175,15 @@ mod set_builtin_performance {
     #[test]
     fn test_options_with_large_script() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable all options
         script_engine::execute_line("set -euxvnfCa", &mut shell_state);
-        
+
         // Execute many commands
         for i in 0..50 {
             script_engine::execute_line(&format!("VAR{}=value{}", i, i), &mut shell_state);
         }
-        
+
         // Options should still be set
         assert!(shell_state.options.errexit);
         assert!(shell_state.options.nounset);
@@ -2160,7 +2199,7 @@ mod set_builtin_performance {
     #[test]
     fn test_memory_efficiency_option_changes() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Perform many option changes
         for i in 0..1000 {
             if i % 2 == 0 {
@@ -2169,7 +2208,7 @@ mod set_builtin_performance {
                 script_engine::execute_line("set +eux", &mut shell_state);
             }
         }
-        
+
         // Should complete without memory issues
         assert_eq!(shell_state.last_exit_code, 0);
     }
@@ -2178,16 +2217,16 @@ mod set_builtin_performance {
     #[test]
     fn test_positional_param_replacement_performance() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Replace positional parameters many times
         for i in 0..100 {
             let cmd = format!("set -- arg{}_1 arg{}_2 arg{}_3", i, i, i);
             script_engine::execute_line(&cmd, &mut shell_state);
-            
+
             // Verify replacement worked
             assert_eq!(shell_state.get_var("1"), Some(format!("arg{}_1", i)));
         }
-        
+
         assert_eq!(shell_state.last_exit_code, 0);
     }
 }
@@ -2204,18 +2243,18 @@ mod subshell_errexit_tests {
     #[test]
     fn test_subshell_inherits_errexit() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Enable errexit in parent
         shell_state.options.errexit = true;
-        
+
         // Execute a subshell with a failing command
         // The subshell will exit early due to errexit, returning exit code 1
         // The parent's errexit will then trigger on the subshell's non-zero exit
         script_engine::execute_line("(false; echo should_not_print)", &mut shell_state);
-        
+
         // Parent errexit should trigger because subshell returned non-zero
         assert!(shell_state.exit_requested);
-        
+
         // Parent option should be unchanged
         assert!(shell_state.options.errexit);
     }
@@ -2225,14 +2264,14 @@ mod subshell_errexit_tests {
     fn test_errexit_triggers_in_subshell_only() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Set a marker variable
         shell_state.set_var("MARKER", "initial".to_string());
-        
+
         // Subshell with failing command, then parent command
         // With errexit, the sequence should stop after subshell fails (just like false; would)
         script_engine::execute_line("(false); MARKER=after_subshell", &mut shell_state);
-        
+
         // Parent errexit should trigger, stopping the sequence
         assert!(shell_state.exit_requested);
         // MARKER should still be "initial" because the assignment didn't run
@@ -2243,10 +2282,10 @@ mod subshell_errexit_tests {
     #[test]
     fn test_subshell_exit_code_propagation() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Execute subshell that exits with specific code
         script_engine::execute_line("(exit 42)", &mut shell_state);
-        
+
         // Parent should see the subshell's exit code
         assert_eq!(shell_state.last_exit_code, 42);
     }
@@ -2256,10 +2295,10 @@ mod subshell_errexit_tests {
     fn test_parent_errexit_on_subshell_failure() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Subshell that fails
         script_engine::execute_line("(false)", &mut shell_state);
-        
+
         // Parent errexit should trigger because subshell returned non-zero
         assert!(shell_state.exit_requested);
         assert_ne!(shell_state.exit_code, 0);
@@ -2270,10 +2309,10 @@ mod subshell_errexit_tests {
     fn test_nested_subshells_errexit() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Nested subshells with failure in innermost
         script_engine::execute_line("((false))", &mut shell_state);
-        
+
         // Parent should have exit_requested set
         assert!(shell_state.exit_requested);
     }
@@ -2282,13 +2321,13 @@ mod subshell_errexit_tests {
     #[test]
     fn test_subshell_errexit_changes_isolated() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Parent has errexit disabled
         shell_state.options.errexit = false;
-        
+
         // Subshell enables errexit
         script_engine::execute_line("(set -e; false)", &mut shell_state);
-        
+
         // Parent errexit should still be disabled
         assert!(!shell_state.options.errexit);
         assert!(!shell_state.exit_requested);
@@ -2299,10 +2338,10 @@ mod subshell_errexit_tests {
     fn test_subshell_errexit_with_success() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Subshell with successful commands
         script_engine::execute_line("(true; echo test)", &mut shell_state);
-        
+
         // Should not trigger errexit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -2313,10 +2352,10 @@ mod subshell_errexit_tests {
     fn test_subshell_errexit_with_conditionals() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Subshell with false in conditional
         script_engine::execute_line("(if false; then echo fail; fi)", &mut shell_state);
-        
+
         // Should not trigger errexit (conditionals are exempt)
         assert!(!shell_state.exit_requested);
     }
@@ -2326,13 +2365,13 @@ mod subshell_errexit_tests {
     fn test_subshell_errexit_with_logical_operators() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // Subshell with false in && chain
         // Inside the subshell, errexit doesn't trigger (logical operator exemption)
         // The subshell returns the exit code of the && chain (1)
         // The parent's errexit then triggers on the subshell's non-zero exit
         script_engine::execute_line("(false && echo should_not_print)", &mut shell_state);
-        
+
         // Parent errexit should trigger because subshell returned non-zero
         assert!(shell_state.exit_requested);
     }
@@ -2342,11 +2381,11 @@ mod subshell_errexit_tests {
     fn test_multiple_subshells_errexit() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // First subshell succeeds
         script_engine::execute_line("(true)", &mut shell_state);
         assert!(!shell_state.exit_requested);
-        
+
         // Second subshell fails
         script_engine::execute_line("(false)", &mut shell_state);
         assert!(shell_state.exit_requested);
@@ -2356,13 +2395,13 @@ mod subshell_errexit_tests {
     #[test]
     fn test_subshell_no_errexit_in_parent() {
         let mut shell_state = state::ShellState::new();
-        
+
         // Parent has errexit disabled
         shell_state.options.errexit = false;
-        
+
         // Subshell with failing command
         script_engine::execute_line("(false; echo should_print)", &mut shell_state);
-        
+
         // Should not trigger exit
         assert!(!shell_state.exit_requested);
     }
@@ -2381,10 +2420,10 @@ mod negation_errexit_tests {
     fn test_negation_false_no_errexit() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // ! false should succeed (exit code 0) and not trigger errexit
         script_engine::execute_line("! false", &mut shell_state);
-        
+
         // Should not exit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -2395,10 +2434,10 @@ mod negation_errexit_tests {
     fn test_negation_true_no_errexit() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // ! true should fail (exit code 1) but not trigger errexit
         script_engine::execute_line("! true", &mut shell_state);
-        
+
         // Should not exit even though exit code is 1
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 1);
@@ -2410,10 +2449,10 @@ mod negation_errexit_tests {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
         shell_state.set_var("MARKER", "initial".to_string());
-        
+
         // ! false succeeds, so next command should run
         script_engine::execute_line("! false; MARKER=after", &mut shell_state);
-        
+
         // Should not exit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.get_var("MARKER"), Some("after".to_string()));
@@ -2424,10 +2463,10 @@ mod negation_errexit_tests {
     fn test_negation_in_pipeline() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // ! false | true should not trigger errexit
         script_engine::execute_line("! false | true", &mut shell_state);
-        
+
         // Should not exit
         assert!(!shell_state.exit_requested);
     }
@@ -2438,10 +2477,10 @@ mod negation_errexit_tests {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
         shell_state.set_var("RESULT", "none".to_string());
-        
+
         // ! false in if condition should work
         script_engine::execute_line("if ! false; then RESULT=success; fi", &mut shell_state);
-        
+
         // Should not exit and condition should succeed
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.get_var("RESULT"), Some("success".to_string()));
@@ -2452,10 +2491,10 @@ mod negation_errexit_tests {
     fn test_negation_with_logical_operators() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // ! false && true should not trigger errexit
         script_engine::execute_line("! false && echo success", &mut shell_state);
-        
+
         // Should not exit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -2465,11 +2504,11 @@ mod negation_errexit_tests {
     #[test]
     fn test_negation_exit_code_inversion() {
         let mut shell_state = state::ShellState::new();
-        
+
         // ! false should return 0
         script_engine::execute_line("! false", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 0);
-        
+
         // ! true should return 1
         script_engine::execute_line("! true", &mut shell_state);
         assert_eq!(shell_state.last_exit_code, 1);
@@ -2480,10 +2519,10 @@ mod negation_errexit_tests {
     fn test_negation_with_external_command() {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
-        
+
         // ! /bin/false should not trigger errexit
         script_engine::execute_line("! /bin/false", &mut shell_state);
-        
+
         // Should not exit
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.last_exit_code, 0);
@@ -2495,10 +2534,10 @@ mod negation_errexit_tests {
         let mut shell_state = state::ShellState::new();
         shell_state.options.errexit = true;
         shell_state.set_var("COUNT", "0".to_string());
-        
+
         // Multiple negated commands in sequence
         script_engine::execute_line("! false; COUNT=1; ! true; COUNT=2", &mut shell_state);
-        
+
         // Should not exit and all commands should execute
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.get_var("COUNT"), Some("2".to_string()));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -676,11 +676,11 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                 match &tokens[i] {
                     Token::RedirOut => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Output(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Output(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirOutClobber => {
@@ -697,20 +697,20 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                     }
                     Token::RedirIn => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Input(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Input(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirAppend => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Append(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Append(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirectFdOut(fd, file) => {
@@ -903,11 +903,11 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                 match &tokens[i] {
                     Token::RedirOut => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Output(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Output(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirOutClobber => {
@@ -924,20 +924,20 @@ fn parse_commands_sequentially(tokens: &[Token]) -> Result<Ast, String> {
                     }
                     Token::RedirIn => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Input(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Input(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirAppend => {
                         i += 1;
-                        if i < tokens.len() {
-                            if let Token::Word(file) = &tokens[i] {
-                                redirections.push(Redirection::Append(file.clone()));
-                                i += 1;
-                            }
+                        if i < tokens.len()
+                            && let Token::Word(file) = &tokens[i]
+                        {
+                            redirections.push(Redirection::Append(file.clone()));
+                            i += 1;
                         }
                     }
                     Token::RedirectFdOut(fd, file) => {
@@ -1340,13 +1340,13 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                     match &tokens[i] {
                         Token::RedirOut => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Output(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Output(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirOutClobber => {
@@ -1365,24 +1365,24 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                         }
                         Token::RedirIn => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Input(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Input(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirAppend => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Append(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Append(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirectFdOut(fd, file) => {
@@ -1490,13 +1490,13 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                     match &tokens[i] {
                         Token::RedirOut => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Output(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Output(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirOutClobber => {
@@ -1515,24 +1515,24 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
                         }
                         Token::RedirIn => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Input(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Input(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirAppend => {
                             i += 1;
-                            if i < tokens.len() {
-                                if let Token::Word(file) = &tokens[i] {
-                                    current_cmd
-                                        .redirections
-                                        .push(Redirection::Append(file.clone()));
-                                    i += 1;
-                                }
+                            if i < tokens.len()
+                                && let Token::Word(file) = &tokens[i]
+                            {
+                                current_cmd
+                                    .redirections
+                                    .push(Redirection::Append(file.clone()));
+                                i += 1;
                             }
                         }
                         Token::RedirectFdOut(fd, file) => {
@@ -1794,7 +1794,6 @@ fn parse_pipeline(tokens: &[Token]) -> Result<Ast, String> {
 
     Ok(Ast::Pipeline(commands))
 }
-
 
 #[cfg(test)]
 mod tests;

--- a/src/script_engine.rs
+++ b/src/script_engine.rs
@@ -115,7 +115,7 @@ pub fn starts_with_keyword(line: &str, keyword: &str) -> bool {
         }
     }
 
-    while let Some(ch) = chars.next() {
+    for ch in chars {
         match ch {
             ' ' | '\t' | '\n' | ';' | '|' | '&' | '(' | ')' | '{' | '}' => {
                 return current_word == keyword;
@@ -156,7 +156,7 @@ pub fn execute_line(line: &str, shell_state: &mut state::ShellState) {
             eprintln!("{}", line);
         }
     }
-    
+
     match lexer::lex(line, shell_state) {
         Ok(tokens) => match lexer::expand_aliases(tokens, shell_state, &mut HashSet::new()) {
             Ok(expanded_tokens) => match brace_expansion::expand_braces(expanded_tokens) {
@@ -208,7 +208,7 @@ pub fn execute_line(line: &str, shell_state: &mut state::ShellState) {
                 eprintln!("Lex error: {}", e);
             }
             shell_state.set_last_exit_code(1);
-            
+
             // Check if this is a nounset error - if so, request shell exit
             if e.contains("unbound variable") {
                 shell_state.exit_requested = true;
@@ -250,11 +250,11 @@ pub fn execute_script(
         state::process_pending_signals(shell_state);
 
         // Check for shutdown signal
-        if let Some(flag) = shutdown_flag {
-            if flag.load(Ordering::Relaxed) {
-                eprintln!("Script interrupted by SIGTERM");
-                break;
-            }
+        if let Some(flag) = shutdown_flag
+            && flag.load(Ordering::Relaxed)
+        {
+            eprintln!("Script interrupted by SIGTERM");
+            break;
         }
 
         // Check if exit was requested (e.g., from trap handler)
@@ -269,10 +269,10 @@ pub fn execute_script(
         }
 
         // Update quote state based on this line
-        let mut chars = line.chars().peekable();
+        let chars = line.chars().peekable();
         let mut escaped = false;
 
-        while let Some(ch) = chars.next() {
+        for ch in chars {
             if escaped {
                 escaped = false;
                 continue;
@@ -327,13 +327,16 @@ pub fn execute_script(
             } else if starts_with_keyword(line, "until") {
                 in_until_block = true;
                 until_depth += 1;
-            } else if {
-                let trimmed = line.trim();
-                trimmed == "{" || trimmed.starts_with("{ ") || trimmed.starts_with("{\t")
-            } {
-                in_group_block = true;
-                brace_depth += line.matches('{').count() as i32;
-                brace_depth -= line.matches('}').count() as i32;
+            } else {
+                let is_group_start = {
+                    let trimmed = line.trim();
+                    trimmed == "{" || trimmed.starts_with("{ ") || trimmed.starts_with("{\t")
+                };
+                if is_group_start {
+                    in_group_block = true;
+                    brace_depth += line.matches('{').count() as i32;
+                    brace_depth -= line.matches('}').count() as i32;
+                }
             }
         }
 
@@ -368,7 +371,13 @@ pub fn execute_script(
                 if if_depth == 0 {
                     in_if_block = false;
                     // Only execute if we're not inside a loop or other block
-                    if !in_for_block && !in_while_block && !in_until_block && !in_function_block && !in_group_block && !in_case_block {
+                    if !in_for_block
+                        && !in_while_block
+                        && !in_until_block
+                        && !in_function_block
+                        && !in_group_block
+                        && !in_case_block
+                    {
                         execute_line(&current_block, shell_state);
                         current_block.clear();
 

--- a/src/script_engine.rs
+++ b/src/script_engine.rs
@@ -27,13 +27,13 @@ pub fn line_contains_heredoc(line: &str, shell_state: &state::ShellState) -> Opt
 /// Check if a line contains a specific keyword as a distinct token
 /// This handles comments and ensures the keyword is not part of another word
 pub fn contains_keyword(line: &str, keyword: &str) -> bool {
-    let mut chars = line.chars().peekable();
+    let chars = line.chars().peekable();
     let mut in_single_quote = false;
     let mut in_double_quote = false;
     let mut escaped = false;
     let mut current_word = String::new();
 
-    while let Some(ch) = chars.next() {
+    for ch in chars {
         if escaped {
             escaped = false;
             // Escaped characters are treated as part of the word

--- a/src/state/fd_table.rs
+++ b/src/state/fd_table.rs
@@ -119,6 +119,7 @@ impl FileDescriptorTable {
     /// # Returns
     /// * `Ok(())` on success
     /// * `Err(String)` with error message on failure
+    #[allow(clippy::too_many_arguments)]
     pub fn open_fd(
         &mut self,
         fd_num: i32,
@@ -378,7 +379,7 @@ impl FileDescriptorTable {
             Some(FileDescriptor::Closed) => None,
             None => {
                 // Standard file descriptors (0, 1, 2) are always open unless explicitly closed
-                if fd_num >= 0 && fd_num <= 2 {
+                if (0..=2).contains(&fd_num) {
                     Some(fd_num as RawFd)
                 } else {
                     None

--- a/src/state/signals.rs
+++ b/src/state/signals.rs
@@ -230,7 +230,10 @@ pub fn enqueue_signal(signal_name: &str, signal_number: i32) {
             // Lock poisoned - another thread panicked while holding the lock
             // Cannot safely enqueue; signal is dropped to avoid cascading failures
             #[cfg(debug_assertions)]
-            eprintln!("Warning: Signal queue lock poisoned, dropping signal {}", signal_name);
+            eprintln!(
+                "Warning: Signal queue lock poisoned, dropping signal {}",
+                signal_name
+            );
         }
     }
 }
@@ -280,30 +283,28 @@ pub fn process_pending_signals(shell_state: &mut ShellState) {
     // This prevents deadlock if a trap handler enqueues a signal
     for signal_event in pending_signals {
         // Check if a trap is set for this signal
-        if let Some(trap_cmd) = shell_state.get_trap(&signal_event.signal_name) {
-            if !trap_cmd.is_empty() {
-                // Display signal information for debugging/tracking
-                if shell_state.colors_enabled {
-                    eprintln!(
-                        "{}Signal {} (signal {}) received at {:?}\x1b[0m",
-                        shell_state.color_scheme.builtin,
-                        signal_event.signal_name,
-                        signal_event.signal_number,
-                        signal_event.timestamp
-                    );
-                } else {
-                    eprintln!(
-                        "Signal {} (signal {}) received at {:?}",
-                        signal_event.signal_name,
-                        signal_event.signal_number,
-                        signal_event.timestamp
-                    );
-                }
-
-                // Execute the trap handler
-                // Note: This preserves the exit code as per POSIX requirements
-                crate::executor::execute_trap_handler(&trap_cmd, shell_state);
+        if let Some(trap_cmd) = shell_state.get_trap(&signal_event.signal_name)
+            && !trap_cmd.is_empty()
+        {
+            // Display signal information for debugging/tracking
+            if shell_state.colors_enabled {
+                eprintln!(
+                    "{}Signal {} (signal {}) received at {:?}\x1b[0m",
+                    shell_state.color_scheme.builtin,
+                    signal_event.signal_name,
+                    signal_event.signal_number,
+                    signal_event.timestamp
+                );
+            } else {
+                eprintln!(
+                    "Signal {} (signal {}) received at {:?}",
+                    signal_event.signal_name, signal_event.signal_number, signal_event.timestamp
+                );
             }
+
+            // Execute the trap handler
+            // Note: This preserves the exit code as per POSIX requirements
+            crate::executor::execute_trap_handler(&trap_cmd, shell_state);
         }
     }
 }


### PR DESCRIPTION
This is the one thing that annoys me about Rust - clippy runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified command execution, redirection parsing, and conditional logic checks across the shell engine for improved code clarity

* **Bug Fixes**
  * Enhanced error reporting for file operations and redirection failures
  * Improved unbound variable error handling with proper exit codes
  * Refined heredoc input processing during interactive sessions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->