### PR TITLE
Add POSIX-compliant $LINENO special variable support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,7 +50,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 - ✅ Variable assignment (VAR=value)
 - ✅ Variable expansion (`$VAR`)
-- ✅ Special parameters: `$?`, `$$`, `$0`
+- ✅ Special parameters: `$?`, `$$`, `$0`, `$LINENO`
 - ✅ Positional parameters (`$1`, `$2`, ...)
 - ✅ Special parameters: `$*`, `$@`, `$#`, `$!`, `$-`
 - ✅ Parameter expansion with modifiers (`${VAR:-default}`, `${VAR#pattern}`, `${VAR/pattern/replacement}`, etc.)

--- a/src/executor/expansion.rs
+++ b/src/executor/expansion.rs
@@ -275,7 +275,7 @@ pub fn expand_variables_in_string(input: &str, shell_state: &mut ShellState) -> 
                         var_name.push(c);
                         chars.next();
                     } else {
-                        // Regular variable name
+                        // Regular variable name (including multi-character special variables like LINENO)
                         while let Some(&c) = next_ch {
                             if c.is_alphanumeric() || c == '_' {
                                 var_name.push(c);

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -524,6 +524,13 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
                 // Execute function body
                 let exit_code = execute(function_body, shell_state);
 
+                // Helper to restore line number from stack
+                let restore_line_number = |state: &mut ShellState| {
+                    if let Some(saved_line) = state.line_number_stack.pop() {
+                        state.current_line_number = saved_line;
+                    }
+                };
+
                 // Check if we got an early return from the function
                 if shell_state.is_returning() {
                     let return_value = shell_state.get_return_value().unwrap_or(0);
@@ -532,9 +539,7 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
                     shell_state.set_positional_params(old_positional);
 
                     // Restore line number
-                    if let Some(saved_line) = shell_state.line_number_stack.pop() {
-                        shell_state.current_line_number = saved_line;
-                    }
+                    restore_line_number(shell_state);
 
                     // Exit function context
                     shell_state.exit_function();

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -517,6 +517,10 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
                 // Set positional parameters for function arguments
                 shell_state.set_positional_params(args.clone());
 
+                // Save current line number and reset to 1 for function body
+                shell_state.line_number_stack.push(shell_state.current_line_number);
+                shell_state.current_line_number = 1;
+
                 // Execute function body
                 let exit_code = execute(function_body, shell_state);
 
@@ -526,6 +530,11 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
 
                     // Restore old positional parameters
                     shell_state.set_positional_params(old_positional);
+
+                    // Restore line number
+                    if let Some(saved_line) = shell_state.line_number_stack.pop() {
+                        shell_state.current_line_number = saved_line;
+                    }
 
                     // Exit function context
                     shell_state.exit_function();
@@ -542,6 +551,11 @@ pub fn execute(ast: Ast, shell_state: &mut ShellState) -> i32 {
 
                 // Restore old positional parameters
                 shell_state.set_positional_params(old_positional);
+
+                // Restore line number
+                if let Some(saved_line) = shell_state.line_number_stack.pop() {
+                    shell_state.current_line_number = saved_line;
+                }
 
                 // Exit function context
                 shell_state.exit_function();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2547,11 +2547,14 @@ mod negation_errexit_tests {
     fn test_lineno_in_script() {
         let mut shell_state = state::ShellState::new();
         
-        let script = "echo line $LINENO\necho line $LINENO\necho line $LINENO";
+        // Set a variable to capture LINENO values
+        let script = "L1=$LINENO\nL2=$LINENO\nL3=$LINENO";
         script_engine::execute_script(script, &mut shell_state, None);
         
-        // Should output lines 1, 2, 3
         assert_eq!(shell_state.last_exit_code, 0);
+        assert_eq!(shell_state.get_var("L1"), Some("1".to_string()));
+        assert_eq!(shell_state.get_var("L2"), Some("2".to_string()));
+        assert_eq!(shell_state.get_var("L3"), Some("3".to_string()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2542,4 +2542,32 @@ mod negation_errexit_tests {
         assert!(!shell_state.exit_requested);
         assert_eq!(shell_state.get_var("COUNT"), Some("2".to_string()));
     }
+
+    #[test]
+    fn test_lineno_in_script() {
+        let mut shell_state = state::ShellState::new();
+        
+        let script = "echo line $LINENO\necho line $LINENO\necho line $LINENO";
+        script_engine::execute_script(script, &mut shell_state, None);
+        
+        // Should output lines 1, 2, 3
+        assert_eq!(shell_state.last_exit_code, 0);
+    }
+
+    #[test]
+    fn test_lineno_in_function() {
+        let mut shell_state = state::ShellState::new();
+        
+        let script = r#"
+test_func() {
+    echo "Function line $LINENO"
+}
+echo "Script line $LINENO"
+test_func
+echo "Script line $LINENO"
+"#;
+        
+        script_engine::execute_script(script, &mut shell_state, None);
+        assert_eq!(shell_state.last_exit_code, 0);
+    }
 }

--- a/src/script_engine.rs
+++ b/src/script_engine.rs
@@ -249,6 +249,10 @@ pub fn execute_script(
 
     while i < lines.len() {
         let line = lines[i];
+        
+        // Update current line number for $LINENO - must be before any continue statements
+        shell_state.current_line_number = i + 1;
+        
         // Process pending signals at the start of each line
         state::process_pending_signals(shell_state);
 
@@ -465,7 +469,5 @@ pub fn execute_script(
             }
         }
         i += 1;
-        // Update current line number for $LINENO
-        shell_state.current_line_number = i + 1;
     }
 }

--- a/src/script_engine.rs
+++ b/src/script_engine.rs
@@ -223,6 +223,9 @@ pub fn execute_script(
     shell_state: &mut state::ShellState,
     shutdown_flag: Option<&AtomicBool>,
 ) {
+    // Reset line number for script execution
+    shell_state.current_line_number = 1;
+    
     let mut current_block = String::new();
     let mut in_if_block = false;
     let mut if_depth = 0;
@@ -462,5 +465,7 @@ pub fn execute_script(
             }
         }
         i += 1;
+        // Update current line number for $LINENO
+        shell_state.current_line_number = i + 1;
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -127,6 +127,10 @@ pub struct ShellState {
     pub in_negation: bool,
     /// Track if the last command executed was a negation (to skip errexit check on inverted code)
     pub last_was_negation: bool,
+    /// Current line number in script execution (for $LINENO)
+    pub current_line_number: usize,
+    /// Stack of line numbers for function calls (to restore after function returns)
+    pub line_number_stack: Vec<usize>,
 }
 
 impl ShellState {
@@ -213,6 +217,8 @@ impl ShellState {
             in_logical_chain: false,
             in_negation: false,
             last_was_negation: false,
+            current_line_number: 1,
+            line_number_stack: Vec::new(),
         }
     }
 
@@ -223,6 +229,7 @@ impl ShellState {
             "?" => Some(self.last_exit_code.to_string()),
             "$" => Some(self.shell_pid.to_string()),
             "0" => Some(self.script_name.clone()),
+            "LINENO" => Some(self.current_line_number.to_string()),
             "*" => {
                 // $* - all positional parameters as single string (space-separated)
                 if self.positional_params.is_empty() {

--- a/src/state/tests/state_tests.rs
+++ b/src/state/tests/state_tests.rs
@@ -119,3 +119,11 @@ fn test_prompt_with_condensed_setting() {
     assert!(prompt_condensed.ends_with("$ ") || prompt_condensed.ends_with("# "));
     assert!(prompt_full.ends_with("$ ") || prompt_full.ends_with("# "));
 }
+
+#[test]
+fn test_lineno_special_variable() {
+    let mut state = ShellState::new();
+    state.current_line_number = 42;
+    
+    assert_eq!(state.get_var("LINENO"), Some("42".to_string()));
+}


### PR DESCRIPTION
Implements the $LINENO special variable that expands to the current line number in scripts and functions, following POSIX IEEE Std 1003.1-2008 semantics.

**Changes**

- Added `current_line_number` and `line_number_stack` fields to `ShellState` for tracking line numbers across execution contexts
- Extended `get_var()` to handle `"LINENO"` as a special variable (like `$?`, `$$`, `$0`)
- Updated `execute_script()` to track line numbers as scripts are processed
- Modified `execute()` to save/restore line numbers across function calls, resetting to line 1 within functions per POSIX requirements

**Testing**

- Added unit test in `src/state/tests/state_tests.rs`
- Added integration tests in `src/main.rs` for scripts and functions

**POSIX Compliance**

This implementation follows POSIX semantics:

- `$LINENO` expands to current line number in script execution
- Functions reset line numbering to 1 (relative to function definition)
- Line numbers properly saved/restored across nested function calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the $LINENO special variable, exposing the current script line number and preserving correct line numbers across function calls, including when functions return early.

* **Documentation**
  * Updated docs to list $LINENO among special parameters.

* **Tests**
  * Added unit tests verifying $LINENO behavior in scripts, functions, and state access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->