### PR TITLE
Expand variables in PS4 for xtrace output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@
 
 ### Recently Implemented Features
 
+- **PS4 Variable Expansion**: Full variable expansion support in PS4 prompt for xtrace output (`set -x`), including special variables like `$LINENO` and support for both `$VAR` and `${VAR}` brace syntax
+- **${VAR} Brace Syntax**: Complete support for brace syntax in variable expansion for all variable types, including special variables like `$LINENO`, `$?`, `$$`, etc.
 - **Set Builtin**: POSIX-compliant `set` command with comprehensive shell option management (errexit, nounset, xtrace, verbose, noexec, noglob, noclobber, allexport), positional parameter control, named options (-o/+o), and display modes - 86+ test cases covering all functionality
 - **Loop Control Builtins**: POSIX-compliant `break` and `continue` commands with support for nested loops via optional [n] argument, working with for/while/until loops, and 29 comprehensive test cases
 - **Subshell Support**: Full POSIX-compliant subshells with state isolation, exit code propagation, trap inheritance, depth limit protection (max 100 levels), and 60+ test cases

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). 
   - Operator precedence with parentheses support
 - **Environment Variables**: Full support for variable assignment, expansion, and export.
   - Variable assignment: `VAR=value` and `VAR="quoted value"`
-  - Variable expansion: `$VAR` and special variables (`$?`, `$$`, `$0`)
+  - Variable expansion: `$VAR` and `${VAR}` (both syntaxes supported for all variable types)
+  - Special variables: `$?`, `$$`, `$0`, `$LINENO` (with full `${VAR}` brace syntax support)
   - **Parameter Expansion with Modifiers**: Advanced variable expansion with POSIX sh modifiers
     - `${VAR:-default}` - use default if VAR is unset or null
     - `${VAR:=default}` - assign default if VAR is unset or null
@@ -1842,7 +1843,7 @@ Rush now provides comprehensive support for the POSIX `set` built-in command, en
 - **8 POSIX Options Supported**:
   - `-e` (errexit): Exit immediately if a command fails
   - `-u` (nounset): Treat unset variables as errors
-  - `-x` (xtrace): Print commands before execution (with PS4 prefix)
+  - `-x` (xtrace): Print commands before execution (with PS4 prefix and variable expansion)
   - `-v` (verbose): Print shell input lines as read
   - `-n` (noexec): Read commands but don't execute (syntax check mode)
   - `-f` (noglob): Disable pathname expansion (globbing)
@@ -1887,7 +1888,7 @@ set                        # Shows all variables (NAME=value format)
 - Options are stored in [`ShellState.options`](src/state.rs:738) structure
 - errexit checks occur after each command execution
 - nounset validation happens during variable expansion
-- xtrace prints to stderr before command execution
+- xtrace prints to stderr before command execution with PS4 variable expansion
 - noexec mode parses but skips execution
 - noglob disables wildcard expansion in pathname expansion
 - noclobber prevents `>` from overwriting (use `>|` to override)

--- a/TODO.md
+++ b/TODO.md
@@ -49,13 +49,14 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 ### 1.5 Parameters and Variables
 
 - ✅ Variable assignment (VAR=value)
-- ✅ Variable expansion (`$VAR`)
-- ✅ Special parameters: `$?`, `$$`, `$0`, `$LINENO`
+- ✅ Variable expansion (`$VAR` and `${VAR}` - both syntaxes supported for all variable types)
+- ✅ Special parameters: `$?`, `$$`, `$0`, `$LINENO` (with full `${VAR}` brace syntax support)
 - ✅ Positional parameters (`$1`, `$2`, ...)
 - ✅ Special parameters: `$*`, `$@`, `$#`, `$!`, `$-`
 - ✅ Parameter expansion with modifiers (`${VAR:-default}`, `${VAR#pattern}`, `${VAR/pattern/replacement}`, etc.)
 - ✅ Indirect expansion (`${!name}`, `${!prefix*}`) - bash extension
 - ✅ Arithmetic expansion (`$((...))`)
+- ✅ PS4 variable expansion for xtrace output (`set -x`)
 
 ### 1.6 Word Expansions
 

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -240,11 +240,11 @@
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">Variable expansion ($VAR)</span>
+                                <span class="item-text">Variable expansion ($VAR and ${VAR} - both syntaxes supported)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">Special parameters: $? $$ $0</span>
+                                <span class="item-text">Special parameters: $? $$ $0 $LINENO (with ${VAR} brace syntax support)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
@@ -261,6 +261,10 @@
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
                                 <span class="item-text">Arithmetic expansion ($((...)))</span>
+                            </div>
+                            <div class="compliance-item implemented">
+                                <span class="status-icon">✅</span>
+                                <span class="item-text">PS4 variable expansion for xtrace output (set -x)</span>
                             </div>
                         </div>
                     </div>

--- a/docs/features.html
+++ b/docs/features.html
@@ -364,9 +364,27 @@ fahrenheit=$((celsius * 9 / 5 + 32))</code></pre>
 
                     <div class="expansion-section">
                         <h3>Parameter Expansion with Modifiers</h3>
-                        <p>Advanced variable expansion with POSIX sh modifiers for powerful string manipulation</p>
+                        <p>Advanced variable expansion with POSIX sh modifiers for powerful string manipulation. Supports both <code>$VAR</code> and <code>${VAR}</code> brace syntax for all variable types including special variables like <code>$LINENO</code>.</p>
 
                         <div class="expansion-examples">
+                            <div class="example-group">
+                                <h4>Variable Expansion Syntax</h4>
+                                <div class="code-block">
+                                    <pre><code># Both syntaxes supported
+echo $HOME
+echo ${HOME}
+
+# Works with special variables
+echo $LINENO
+echo ${LINENO}
+
+# PS4 variable expansion for xtrace
+PS4='+ ${LINENO}: '
+set -x
+echo "Debug output"</code></pre>
+                                </div>
+                            </div>
+
                             <div class="example-group">
                                 <h4>Default Values</h4>
                                 <div class="code-block">

--- a/src/executor/command.rs
+++ b/src/executor/command.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use crate::parser::{Ast, ShellCommand};
 use crate::state::ShellState;
 
-use super::expansion::{expand_variables_in_args, expand_wildcards};
+use super::expansion::{expand_variables_in_args, expand_variables_in_string, expand_wildcards};
 use super::redirection::apply_redirections;
 use super::{execute, execute_compound_in_pipeline, execute_compound_with_redirections};
 
@@ -266,9 +266,12 @@ pub(crate) fn execute_single_command(cmd: &ShellCommand, shell_state: &mut Shell
     // Print command if xtrace is enabled (-x)
     if shell_state.options.xtrace {
         // Get PS4 prompt (default: "+ ")
-        let ps4 = shell_state
+        let ps4_raw = shell_state
             .get_var("PS4")
             .unwrap_or_else(|| "+ ".to_string());
+        
+        // Expand variables in PS4 (e.g., $LINENO)
+        let ps4 = expand_variables_in_string(&ps4_raw, shell_state);
 
         // Print the command with expanded arguments to stderr
         let command_str = expanded_args.join(" ");

--- a/src/executor/expansion.rs
+++ b/src/executor/expansion.rs
@@ -260,6 +260,51 @@ pub fn expand_variables_in_string(input: &str, shell_state: &mut ShellState) -> 
                     result.push_str(&sub_command);
                     result.push(')');
                 }
+            } else if let Some(&'{') = chars.peek() {
+                // ${VAR} syntax
+                chars.next(); // consume the {
+                let mut var_name = String::new();
+                let mut found_closing = false;
+
+                // Read until we find the closing }
+                while let Some(c) = chars.next() {
+                    if c == '}' {
+                        found_closing = true;
+                        break;
+                    }
+                    var_name.push(c);
+                }
+
+                if found_closing && !var_name.is_empty() {
+                    if let Some(value) = shell_state.get_var(&var_name) {
+                        result.push_str(&value);
+                    } else {
+                        // Variable not found - for positional parameters, expand to empty string
+                        // For other variables, keep the literal
+                        if var_name.chars().next().unwrap().is_ascii_digit()
+                            || var_name == "?"
+                            || var_name == "$"
+                            || var_name == "0"
+                            || var_name == "#"
+                            || var_name == "*"
+                            || var_name == "@"
+                        {
+                            // Expand to empty string for undefined positional parameters
+                        } else {
+                            // Keep the literal for regular variables
+                            result.push_str("${");
+                            result.push_str(&var_name);
+                            result.push('}');
+                        }
+                    }
+                } else {
+                    // Malformed ${...} - keep as literal
+                    result.push_str("${");
+                    result.push_str(&var_name);
+                    if !found_closing {
+                        // No closing brace found
+                    }
+                }
             } else {
                 // Regular variable
                 let mut var_name = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -476,6 +476,18 @@ mod tests {
         assert_eq!(shell_state.last_exit_code, 0);
     }
 
+    #[test]
+    fn test_xtrace_with_ps4_expansion() {
+        let mut shell_state = state::ShellState::new();
+        shell_state.current_line_number = 42;
+        shell_state.set_var("PS4", "+ [${LINENO}] ".to_string());
+        shell_state.options.xtrace = true;
+        
+        script_engine::execute_line("echo test", &mut shell_state);
+        
+        assert_eq!(shell_state.last_exit_code, 0);
+    }
+
     /// Test nounset option (-u): Unset variables should cause errors during execution
     #[test]
     fn test_nounset_basic() {


### PR DESCRIPTION
- Import expand_variables_in_string in command.rs
- Expand PS4 variable before printing in xtrace mode
- Add support for ${VAR} syntax in expansion.rs
- Add test_xtrace_with_ps4_expansion test
- Fixes PS4 to properly expand variables like LINENO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PS4 variable expansion support for xtrace output, enabling variables like $LINENO to be expanded in trace output
  * Added ${VAR} brace syntax support for all variable types, including special variables such as $LINENO and $?

* **Documentation**
  * Updated documentation to reflect new brace syntax support and enhanced variable expansion capabilities across all features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->