### PR TITLE
Implement the colon builtin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 
 - **Compliance Level**: ~94% POSIX compliant
 - **Test Coverage**: 499+ test functions across all components
-- **Built-in Commands**: 25 implemented commands
+- **Built-in Commands**: 26 implemented commands
 - **Core Features**: Full variable expansion, arithmetic evaluation, control structures, functions with return, shell options
 - **Architecture**: Modular design with separate lexer, parser, executor, and expansion engines
 
@@ -637,7 +637,7 @@ impl ShellState {
 
 ### High Priority (Core POSIX Features)
 
-1. **Missing Built-ins**: `eval`, `exec`, `readonly`, `:` (colon)
+1. **Missing Built-ins**: `eval`, `exec`, `readonly`
 2. **Job Control**: Background jobs (`&`), job management (`bg`, `fg`, `jobs`)
 
 ### Medium Priority

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Rush Logo](images/rush_logo.png)
 
-Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). It provides both interactive mode with a REPL prompt and script mode for executing commands from files. The shell supports comprehensive shell features including command execution, pipes, redirections, subshells, file descriptor operations, environment variables, and 25 built-in commands.
+Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). It provides both interactive mode with a REPL prompt and script mode for executing commands from files. The shell supports comprehensive shell features including command execution, pipes, redirections, subshells, file descriptor operations, environment variables, and 26 built-in commands.
 
 ## Table of Contents
 
@@ -119,7 +119,8 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). 
     - Return statements: `return [value]`
     - Function introspection: `declare -f [function_name]`
   - **Command Grouping**: Group commands in the current shell context using `{ commands; }` syntax
-- **Built-in Commands** (25 total):
+- **Built-in Commands** (26 total):
+  - `:` (colon): Null command that always returns success
   - `alias`: Define or display aliases
   - `break`: Exit from for, while, or until loops with optional [n] for nested loops
   - `cd`: Change directory
@@ -171,7 +172,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). 
 
 **Advanced Arithmetic Expansion** - Complete `$((...))` arithmetic expression evaluator with proper operator precedence, variable integration, bitwise operations, logical operations, and comprehensive error handling using the Shunting-yard algorithm.
 
-**Enhanced Built-in Command Suite** - Comprehensive set of 25 built-in commands including loop control (`break`/`continue`), directory stack management (`pushd`/`popd`/`dirs`), alias management (`alias`/`unalias`), color theming (`set_colors`/`set_color_scheme`), function introspection (`declare`), signal handling (`trap`), command type inspection (`type`), function returns (`return`), shell options (`set`), and POSIX-compliant `test` builtin.
+**Enhanced Built-in Command Suite** - Comprehensive set of 26 built-in commands including the colon (`:`) null command, loop control (`break`/`continue`), directory stack management (`pushd`/`popd`/`dirs`), alias management (`alias`/`unalias`), color theming (`set_colors`/`set_color_scheme`), function introspection (`declare`), signal handling (`trap`), command type inspection (`type`), function returns (`return`), shell options (`set`), and POSIX-compliant `test` builtin.
 
 **Intelligent Tab Completion** - Advanced completion system for commands, files, directories, and paths with support for nested directory traversal and home directory expansion.
 
@@ -2395,7 +2396,7 @@ This benchmark suite provides a foundation for maintaining optimal shell perform
 The test suite provides extensive coverage of:
 
 - Command parsing and execution
-- Built-in command functionality (all 25 built-in commands including alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, [, trap, type, unalias, unset)
+- Built-in command functionality (all 26 built-in commands including : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, [, trap, type, unalias, unset)
 - **Subshells** (state isolation, exit code propagation, trap inheritance, depth limits, 60+ test cases)
 - **File descriptor operations** (duplication, closing, read/write modes, 30+ test cases)
 - Pipeline and redirection handling

--- a/TODO.md
+++ b/TODO.md
@@ -279,7 +279,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 ### Areas Without Tests (due to unimplemented features)
 
-- ❌ Missing built-in functionality (eval, exec, readonly, :, times, umask, wait)
+- ❌ Missing built-in functionality (eval, exec, readonly, times, umask, wait)
 - ❌ Job control features (bg, fg, jobs, &)
 
 ## Compliance Metrics

--- a/TODO.md
+++ b/TODO.md
@@ -129,7 +129,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 ### Required Special Built-ins
 
 - ✅ break (implemented)
-- ❌ : (colon - not implemented)
+- ✅ : (colon - implemented)
 - ✅ continue (implemented)
 - ❌ eval (not implemented)
 - ❌ exec (not implemented)
@@ -147,13 +147,13 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 ### Current Built-in Status
 
-**Implemented (25):**
+**Implemented (26):**
 
-- alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, trap, type, unalias, unset
+- : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, trap, type, unalias, unset
 
 **Missing POSIX Built-ins:**
 
-- **Special Built-ins**: :, eval, exec, readonly, times, umask, wait
+- **Special Built-ins**: eval, exec, readonly, times, umask, wait
 - **Note**: Many common built-ins are implemented (alias, dirs, pushd/popd, source, test, return, set, color management)
 
 ## 4. Regular Built-in Utilities
@@ -230,7 +230,6 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
     - `eval` (evaluate string as shell command)
     - `exec` (replace shell with command)
     - `readonly` (mark variables as read-only)
-    - `:` (colon - null command)
     - `times` (print accumulated times)
     - `umask` (set file creation mask)
     - `wait` (wait for background jobs)
@@ -257,7 +256,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 - ✅ **Lexer tests** (tokenization, expansion, quoting, arithmetic, parameter expansion)
 - ✅ **Parser tests** (AST construction, control structures, if/elif/else, case statements)
 - ✅ **Executor tests** (command execution, pipelines, redirections, built-in commands)
-- ✅ **Built-in tests** (all 24 implemented commands with comprehensive coverage)
+- ✅ **Built-in tests** (all 26 implemented commands with comprehensive coverage)
 - ✅ **Integration tests** (end-to-end scenarios, variable expansion, control structures)
 - ✅ **Arithmetic expansion tests** (operators, precedence, variables, error handling)
 - ✅ **Parameter expansion tests** (all modifiers, pattern matching, indirect expansion, edge cases)
@@ -291,7 +290,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 - **Basic Execution**: 95% ✅
 - **Control Structures**: 95% ✅ (if/elif/else, case with glob patterns, for/while/until loops, functions with return, subshells, command grouping implemented)
-- **Built-in Commands**: 81% ✅ (25 built-ins implemented out of 31 POSIX required, including critical `set` builtin)
+- **Built-in Commands**: 84% ✅ (26 built-ins implemented out of 31 POSIX required, including critical `set` builtin)
 - **Expansions**: 98% ✅ (Parameter expansion with indirect expansion, arithmetic expansion, and brace expansion fully implemented)
 - **Redirections**: 95% ✅ (Full I/O redirection, here-documents, here-strings, and file descriptor operations implemented)
 - **Job Control**: 0% ❌ (optional POSIX feature)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -231,7 +231,7 @@
                                         </div>
                                         <div class="component-content">
                                             <ul>
-                                                <li>25 built-in commands</li>
+                                                <li>26 built-in commands</li>
                                                 <li>Optimized execution</li>
                                                 <li>No process spawning</li>
                                                 <li>Direct state access</li>

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -120,7 +120,7 @@ v0.7.2<!DOCTYPE html>
                                 <div class="stat-label">Overall Compliance</div>
                             </div>
                             <div class="stat-item">
-                                <div class="stat-number">25</div>
+                                <div class="stat-number">26</div>
                                 <div class="stat-label">Built-in Commands</div>
                             </div>
                             <div class="stat-item">
@@ -471,8 +471,8 @@ v0.7.2<!DOCTYPE html>
                         <div class="status-summary">
                             <h3>Implementation Status</h3>
                             <div class="status-badges">
-                                <span class="badge implemented">25 Implemented</span>
-                                <span class="badge missing">7 Missing</span>
+                                <span class="badge implemented">26 Implemented</span>
+                                <span class="badge missing">6 Missing</span>
                             </div>
                         </div>
 
@@ -484,8 +484,8 @@ v0.7.2<!DOCTYPE html>
                                         <span class="status-icon">✅</span>
                                         <span class="item-text">break</span>
                                     </div>
-                                    <div class="compliance-item missing">
-                                        <span class="status-icon">❌</span>
+                                    <div class="compliance-item implemented">
+                                        <span class="status-icon">✅</span>
                                         <span class="item-text">: (colon)</span>
                                     </div>
                                     <div class="compliance-item implemented">
@@ -548,8 +548,9 @@ v0.7.2<!DOCTYPE html>
                             </div>
 
                             <div class="builtins-column">
-                                <h4>Currently Implemented (25)</h4>
+                                <h4>Currently Implemented (26)</h4>
                                 <div class="implemented-list">
+                                    <div class="builtin-tag">: (colon)</div>
                                     <div class="builtin-tag">alias</div>
                                     <div class="builtin-tag">break</div>
                                     <div class="builtin-tag">cd</div>
@@ -593,7 +594,7 @@ v0.7.2<!DOCTYPE html>
                                     <ul>
                                         <li>eval</li>
                                         <li>exec</li>
-                                        <li>readonly, : (colon), etc.</li>
+                                        <li>readonly, etc.</li>
                                     </ul>
                                 </li>
                                 </ul>
@@ -643,7 +644,7 @@ v0.7.2<!DOCTYPE html>
                                 <div class="test-label">Core Components Covered</div>
                             </div>
                             <div class="test-stat">
-                                <div class="test-number">25</div>
+                                <div class="test-number">26</div>
                                 <div class="test-label">Built-ins Tested</div>
                             </div>
                         </div>
@@ -761,7 +762,7 @@ v0.7.2<!DOCTYPE html>
                                 </div>
                                 <div class="breakdown-item">
                                     <span class="category">Built-in Commands</span>
-                                    <span class="percentage implemented">77%</span>
+                                    <span class="percentage implemented">81%</span>
                                 </div>
                                 <div class="breakdown-item">
                                     <span class="category">Expansions</span>

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -1,4 +1,4 @@
-v0.7.2<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -596,8 +596,6 @@ v0.7.2<!DOCTYPE html>
                                         <li>exec</li>
                                         <li>readonly, etc.</li>
                                     </ul>
-                                </li>
-                                </ul>
                                 </li>
                             </ol>
                         </div>

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -304,7 +304,7 @@ v0.7.2<!DOCTYPE html>
                         <div class="compliance-grid">
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">Input redirection (<)< /span>
+                                <span class="item-text">Input redirection (&lt;)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
@@ -316,23 +316,23 @@ v0.7.2<!DOCTYPE html>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">Here-document (<<)< /span>
+                                <span class="item-text">Here-document (&lt;&lt;)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">Here-string (<<<)< /span>
+                                <span class="item-text">Here-string (&lt;&lt;&lt;)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">File descriptor duplication (N>&M, N<&M)< /span>
+                                <span class="item-text">File descriptor duplication (N>&amp;M, N&lt;&amp;M)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">File descriptor closing (N>&-, N<&-)< /span>
+                                <span class="item-text">File descriptor closing (N>&amp;-, N&lt;&amp;-)</span>
                             </div>
                             <div class="compliance-item implemented">
                                 <span class="status-icon">✅</span>
-                                <span class="item-text">File descriptor read/write (N<>)</span>
+                                <span class="item-text">File descriptor read/write (N&lt;>)</span>
                             </div>
                         </div>
                     </div>

--- a/docs/features.html
+++ b/docs/features.html
@@ -364,7 +364,9 @@ fahrenheit=$((celsius * 9 / 5 + 32))</code></pre>
 
                     <div class="expansion-section">
                         <h3>Parameter Expansion with Modifiers</h3>
-                        <p>Advanced variable expansion with POSIX sh modifiers for powerful string manipulation. Supports both <code>$VAR</code> and <code>${VAR}</code> brace syntax for all variable types including special variables like <code>$LINENO</code>.</p>
+                        <p>Advanced variable expansion with POSIX sh modifiers for powerful string manipulation.
+                            Supports both <code>$VAR</code> and <code>${VAR}</code> brace syntax for all variable types
+                            including special variables like <code>$LINENO</code>.</p>
 
                         <div class="expansion-examples">
                             <div class="example-group">
@@ -667,6 +669,13 @@ local var="value"</code></pre>
                                     <li><code>declare</code> - Function introspection</li>
                                     <li><code>type</code> - Display information about command type (alias, keyword,
                                         function, builtin, or external command)</li>
+                                </ul>
+                            </div>
+
+                            <div class="builtin-category">
+                                <h4>Utility</h4>
+                                <ul>
+                                    <li><code>:</code> - Null command (no-op), always returns success</li>
                                 </ul>
                             </div>
                         </div>

--- a/docs/features.html
+++ b/docs/features.html
@@ -587,7 +587,7 @@ local var="value"</code></pre>
                     <h2>🛠️ Built-in Commands</h2>
 
                     <div class="builtins-overview">
-                        <p>Rush includes <strong>25 comprehensive built-in commands</strong> for enhanced functionality
+                        <p>Rush includes <strong>26 comprehensive built-in commands</strong> for enhanced functionality
                             and performance:</p>
 
                         <div class="builtins-grid">

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,7 +122,7 @@
                                     <div class="stat-label">POSIX Compliant</div>
                                 </div>
                                 <div class="stat">
-                                    <div class="stat-value">25</div>
+                                    <div class="stat-value">26</div>
                                     <div class="stat-label">Built-in Commands</div>
                                 </div>
                                 <div class="stat">

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -41,6 +41,7 @@ impl Write for BadFdWriter {
 mod builtin_alias;
 mod builtin_break;
 mod builtin_cd;
+mod builtin_colon;
 mod builtin_continue;
 mod builtin_declare;
 mod builtin_dirs;
@@ -117,6 +118,7 @@ fn get_builtins() -> Vec<Box<dyn Builtin>> {
         Box::new(builtin_return::ReturnBuiltin),
         Box::new(builtin_break::BreakBuiltin),
         Box::new(builtin_continue::ContinueBuiltin),
+        Box::new(builtin_colon::ColonBuiltin),
     ]
 }
 
@@ -444,6 +446,7 @@ mod tests {
         assert!(commands.contains(&"break".to_string()));
         assert!(commands.contains(&"continue".to_string()));
         assert!(commands.contains(&"set".to_string()));
-        assert_eq!(commands.len(), 27);
+        assert!(commands.contains(&":".to_string()));
+        assert_eq!(commands.len(), 28);
     }
 }

--- a/src/builtins/builtin_colon.rs
+++ b/src/builtins/builtin_colon.rs
@@ -1,0 +1,269 @@
+use std::io::Write;
+
+use crate::parser::ShellCommand;
+use crate::state::ShellState;
+
+/// The POSIX no-op (`:`) builtin command.
+///
+/// Per POSIX.1-2008, the colon utility does nothing and always returns exit status 0.
+/// It is primarily used for:
+/// - Placeholder in control structures (e.g., `if :; then ...`)
+/// - Forcing variable expansion without executing commands (e.g., `: ${VAR:?error}`)
+/// - Creating infinite loops (e.g., `while :; do ...`)
+/// - Consuming arguments that should be expanded but not used
+///
+/// # POSIX Compliance
+///
+/// The colon command accepts any number of arguments, which are subject to normal
+/// shell expansions (variable expansion, command substitution, etc.), but the
+/// arguments are then ignored. The command always exits with status 0.
+///
+/// # Examples
+///
+/// ```sh
+/// # Basic usage - does nothing, returns 0
+/// :
+///
+/// # With arguments - arguments are expanded but ignored
+/// : "This is ignored"
+/// : $VAR $(command)
+///
+/// # Force parameter expansion with error checking
+/// : ${VAR:?Variable VAR is not set}
+///
+/// # Placeholder in if statement
+/// if :; then
+///     echo "This always executes"
+/// fi
+///
+/// # Infinite loop
+/// while :; do
+///     echo "Press Ctrl+C to stop"
+///     sleep 1
+/// done
+///
+/// # With redirections - redirections are still applied
+/// : > file.txt  # Creates or truncates file.txt
+/// ```
+pub struct ColonBuiltin;
+
+impl super::Builtin for ColonBuiltin {
+    fn name(&self) -> &'static str {
+        ":"
+    }
+
+    fn names(&self) -> Vec<&'static str> {
+        vec![self.name()]
+    }
+
+    fn description(&self) -> &'static str {
+        "Do nothing, successfully (POSIX no-op)"
+    }
+
+    fn run(
+        &self,
+        _cmd: &ShellCommand,
+        _shell_state: &mut ShellState,
+        _output_writer: &mut dyn Write,
+    ) -> i32 {
+        // Per POSIX: The colon utility does nothing and always returns exit status 0.
+        // Arguments are already expanded by the shell before reaching this point,
+        // so we simply ignore them and return success.
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::Builtin;
+    use crate::parser::Redirection;
+
+    #[test]
+    fn test_colon_builtin_no_args() {
+        let cmd = ShellCommand {
+            args: vec![":".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0); // No output should be produced
+    }
+
+    #[test]
+    fn test_colon_builtin_with_string_args() {
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                "arg1".to_string(),
+                "arg2".to_string(),
+                "arg3".to_string(),
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0); // No output should be produced
+    }
+
+    #[test]
+    fn test_colon_builtin_with_special_chars() {
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                "!@#$%^&*()".to_string(),
+                "spaces here".to_string(),
+                "tabs\there".to_string(),
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0);
+    }
+
+    #[test]
+    fn test_colon_builtin_with_numbers() {
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                "123".to_string(),
+                "456".to_string(),
+                "-789".to_string(),
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0);
+    }
+
+    #[test]
+    fn test_colon_builtin_always_returns_zero() {
+        // Test multiple invocations to ensure it always returns 0
+        let builtin = ColonBuiltin;
+        let mut shell_state = ShellState::new();
+
+        for _ in 0..10 {
+            let cmd = ShellCommand {
+                args: vec![":".to_string()],
+                redirections: Vec::new(),
+                compound: None,
+            };
+            let mut output = Vec::new();
+            let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+            assert_eq!(exit_code, 0);
+        }
+    }
+
+    #[test]
+    fn test_colon_builtin_with_expanded_variables() {
+        // Note: Variable expansion happens before the builtin is called,
+        // so we test that the builtin handles already-expanded arguments
+        let mut shell_state = ShellState::new();
+        shell_state.set_var("TEST_VAR", "test_value".to_string());
+
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                "test_value".to_string(), // This would be the result of $TEST_VAR expansion
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0);
+    }
+
+    #[test]
+    fn test_colon_builtin_with_redirections() {
+        // Test that the builtin works with redirections
+        // (The actual redirection handling is done by execute_builtin, not the builtin itself)
+        let cmd = ShellCommand {
+            args: vec![":".to_string()],
+            redirections: vec![Redirection::Output("/tmp/test_colon_output.txt".to_string())],
+            compound: None,
+        };
+
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        // The builtin itself doesn't handle redirections, so output should still be empty
+        assert_eq!(output.len(), 0);
+    }
+
+    #[test]
+    fn test_colon_builtin_name() {
+        let builtin = ColonBuiltin;
+        assert_eq!(builtin.name(), ":");
+        assert_eq!(builtin.names(), vec![":"]);
+    }
+
+    #[test]
+    fn test_colon_builtin_description() {
+        let builtin = ColonBuiltin;
+        assert!(!builtin.description().is_empty());
+        assert!(builtin.description().contains("no-op") || builtin.description().contains("nothing"));
+    }
+
+    #[test]
+    fn test_colon_builtin_with_empty_strings() {
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                "".to_string(),
+                "".to_string(),
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0);
+    }
+
+    #[test]
+    fn test_colon_builtin_with_very_long_args() {
+        let long_string = "a".repeat(10000);
+        let cmd = ShellCommand {
+            args: vec![
+                ":".to_string(),
+                long_string.clone(),
+                long_string.clone(),
+            ],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = ColonBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        assert_eq!(exit_code, 0);
+        assert_eq!(output.len(), 0);
+    }
+}

--- a/src/builtins/builtin_colon.rs
+++ b/src/builtins/builtin_colon.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use crate::parser::ShellCommand;
 use crate::state::ShellState;
 
-/// The POSIX no-op (`:`) builtin command.
+/// The no-op (`:`) builtin command.
 ///
-/// Per POSIX.1-2008, the colon utility does nothing and always returns exit status 0.
+/// The colon utility does nothing and always returns exit status 0.
 /// It is primarily used for:
 /// - Placeholder in control structures (e.g., `if :; then ...`)
 /// - Forcing variable expansion without executing commands (e.g., `: ${VAR:?error}`)
@@ -14,9 +14,10 @@ use crate::state::ShellState;
 ///
 /// # POSIX Compliance
 ///
-/// The colon command accepts any number of arguments, which are subject to normal
-/// shell expansions (variable expansion, command substitution, etc.), but the
-/// arguments are then ignored. The command always exits with status 0.
+/// This builtin is *not* part of POSIX standards. The colon command accepts any 
+/// number of arguments, which are subject to normal shell expansions (variable 
+/// expansion, command substitution, etc.), but the arguments are then ignored. 
+/// The command always exits with status 0.
 ///
 /// # Examples
 ///
@@ -66,7 +67,7 @@ impl super::Builtin for ColonBuiltin {
         _shell_state: &mut ShellState,
         _output_writer: &mut dyn Write,
     ) -> i32 {
-        // Per POSIX: The colon utility does nothing and always returns exit status 0.
+        // The colon utility does nothing and always returns exit status 0.
         // Arguments are already expanded by the shell before reaching this point,
         // so we simply ignore them and return success.
         0

--- a/src/builtins/builtin_colon.rs
+++ b/src/builtins/builtin_colon.rs
@@ -14,10 +14,10 @@ use crate::state::ShellState;
 ///
 /// # POSIX Compliance
 ///
-/// This builtin is *not* part of POSIX standards. The colon command accepts any 
-/// number of arguments, which are subject to normal shell expansions (variable 
-/// expansion, command substitution, etc.), but the arguments are then ignored. 
-/// The command always exits with status 0.
+/// The colon (`:`) is a POSIX special built-in command per IEEE Std 1003.1.
+/// It accepts any number of arguments, which are subject to normal shell 
+/// expansions (variable expansion, command substitution, etc.), but the 
+/// arguments are then ignored. The command always exits with status 0.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This change implements the colon (no-op) builtin from shells like Bash and ksh. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated POSIX compliance and site docs so shell redirection symbols (e.g., <, <<, <<< and fd ops) render correctly; updated headings, counts, and compliance metrics to reflect the new total of built-ins.

* **New Features**
  * Added the POSIX no-op colon operator (:) as a built-in command; it succeeds with no output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->