### PR TITLE
Add POSIX times built-in command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,13 @@
 
 - **Compliance Level**: ~94% POSIX compliant
 - **Test Coverage**: 499+ test functions across all components
-- **Built-in Commands**: 26 implemented commands
+- **Built-in Commands**: 27 implemented commands
 - **Core Features**: Full variable expansion, arithmetic evaluation, control structures, functions with return, shell options
 - **Architecture**: Modular design with separate lexer, parser, executor, and expansion engines
 
 ### Recently Implemented Features
 
+- **Times Builtin**: POSIX-compliant `times` command displaying accumulated user and system CPU times for the shell and child processes, with proper time formatting (XmY.ZZs) and 7 comprehensive test cases
 - **PS4 Variable Expansion**: Full variable expansion support in PS4 prompt for xtrace output (`set -x`), including special variables like `$LINENO` and support for both `$VAR` and `${VAR}` brace syntax
 - **${VAR} Brace Syntax**: Complete support for brace syntax in variable expansion for all variable types, including special variables like `$LINENO`, `$?`, `$$`, etc.
 - **Set Builtin**: POSIX-compliant `set` command with comprehensive shell option management (errexit, nounset, xtrace, verbose, noexec, noglob, noclobber, allexport), positional parameter control, named options (-o/+o), and display modes - 86+ test cases covering all functionality
@@ -93,7 +94,7 @@ src/
 ├── script_engine.rs     # Script execution engine
 ├── builtins.rs          # Builtin dispatcher
 ├── builtins/            # Individual builtin commands
-│   ├── builtin_*.rs     # 25+ builtin implementations
+│   ├── builtin_*.rs     # 26+ builtin implementations
 └── lib.rs               # Library exports
 ```
 

--- a/README.md
+++ b/README.md
@@ -2209,7 +2209,7 @@ Rush features a modular architecture with well-organized components for maintain
 
 ### Supporting Components
 
-- **Built-in Commands** ([`src/builtins/`](src/builtins/)): 26 optimized built-in commands with direct state access
+- **Built-in Commands** ([`src/builtins/`](src/builtins/)): 27 optimized built-in commands with direct state access
 - **Completion** ([`src/completion.rs`](src/completion.rs)): Intelligent tab-completion for commands, files, and directories
 - **Script Engine** ([`src/script_engine.rs`](src/script_engine.rs)): Script file execution with proper error handling
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![Rush Logo](images/rush_logo.png)
 
-Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). It provides both interactive mode with a REPL prompt and script mode for executing commands from files. The shell supports comprehensive shell features including command execution, pipes, redirections, subshells, file descriptor operations, environment variables, and 26 built-in commands.
+Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). It provides both interactive mode with a REPL prompt and script mode for executing commands from files. The shell supports comprehensive shell features including command execution, pipes, redirections, subshells, file descriptor operations, environment variables, and 27 built-in commands.
 
 ## Table of Contents
 
@@ -119,7 +119,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). 
     - Return statements: `return [value]`
     - Function introspection: `declare -f [function_name]`
   - **Command Grouping**: Group commands in the current shell context using `{ commands; }` syntax
-- **Built-in Commands** (26 total):
+- **Built-in Commands** (27 total):
   - `:` (colon): Null command that always returns success
   - `alias`: Define or display aliases
   - `break`: Exit from for, while, or until loops with optional [n] for nested loops
@@ -142,6 +142,7 @@ Rush is a POSIX sh-compatible shell implemented in Rust (~94% POSIX compliant). 
   - `shift`: Shift positional parameters
   - `source` / `.`: Execute a script file with rush (bypasses shebang and comment lines)
   - `test` / `[`: POSIX-compatible test builtin with string and file tests
+  - `times`: Display accumulated user and system CPU times for the shell and its child processes
   - `trap`: Set or display signal handlers
   - `type`: Display information about command type (alias, keyword, function, builtin, or external command)
   - `unalias`: Remove alias definitions
@@ -2208,7 +2209,7 @@ Rush features a modular architecture with well-organized components for maintain
 
 ### Supporting Components
 
-- **Built-in Commands** ([`src/builtins/`](src/builtins/)): 25 optimized built-in commands with direct state access
+- **Built-in Commands** ([`src/builtins/`](src/builtins/)): 26 optimized built-in commands with direct state access
 - **Completion** ([`src/completion.rs`](src/completion.rs)): Intelligent tab-completion for commands, files, and directories
 - **Script Engine** ([`src/script_engine.rs`](src/script_engine.rs)): Script file execution with proper error handling
 
@@ -2396,7 +2397,7 @@ This benchmark suite provides a foundation for maintaining optimal shell perform
 The test suite provides extensive coverage of:
 
 - Command parsing and execution
-- Built-in command functionality (all 26 built-in commands including : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, [, trap, type, unalias, unset)
+- Built-in command functionality (all 27 built-in commands including : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, [, times, trap, type, unalias, unset)
 - **Subshells** (state isolation, exit code propagation, trap inheritance, depth limits, 60+ test cases)
 - **File descriptor operations** (duplication, closing, read/write modes, 30+ test cases)
 - Pipeline and redirection handling

--- a/TODO.md
+++ b/TODO.md
@@ -139,7 +139,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 - ✅ return (implemented)
 - ✅ set (implemented with 8 POSIX options)
 - ✅ shift (implemented)
-- ❌ times (not implemented)
+- ✅ times (implemented)
 - ✅ trap (implemented)
 - ❌ umask (not implemented)
 - ✅ unset (implemented)
@@ -147,13 +147,13 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 ### Current Built-in Status
 
-**Implemented (26):**
+**Implemented (27):**
 
-- : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, trap, type, unalias, unset
+- : (colon), alias, break, cd, continue, declare, dirs, env, exit, export, help, popd, pushd, pwd, return, set, set_color_scheme, set_colors, set_condensed, shift, source, test, times, trap, type, unalias, unset
 
 **Missing POSIX Built-ins:**
 
-- **Special Built-ins**: eval, exec, readonly, times, umask, wait
+- **Special Built-ins**: eval, exec, readonly, umask, wait
 - **Note**: Many common built-ins are implemented (alias, dirs, pushd/popd, source, test, return, set, color management)
 
 ## 4. Regular Built-in Utilities
@@ -230,7 +230,6 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
     - `eval` (evaluate string as shell command)
     - `exec` (replace shell with command)
     - `readonly` (mark variables as read-only)
-    - `times` (print accumulated times)
     - `umask` (set file creation mask)
     - `wait` (wait for background jobs)
 
@@ -256,7 +255,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 - ✅ **Lexer tests** (tokenization, expansion, quoting, arithmetic, parameter expansion)
 - ✅ **Parser tests** (AST construction, control structures, if/elif/else, case statements)
 - ✅ **Executor tests** (command execution, pipelines, redirections, built-in commands)
-- ✅ **Built-in tests** (all 26 implemented commands with comprehensive coverage)
+- ✅ **Built-in tests** (all 27 implemented commands with comprehensive coverage)
 - ✅ **Integration tests** (end-to-end scenarios, variable expansion, control structures)
 - ✅ **Arithmetic expansion tests** (operators, precedence, variables, error handling)
 - ✅ **Parameter expansion tests** (all modifiers, pattern matching, indirect expansion, edge cases)
@@ -279,7 +278,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 ### Areas Without Tests (due to unimplemented features)
 
-- ❌ Missing built-in functionality (eval, exec, readonly, times, umask, wait)
+- ❌ Missing built-in functionality (eval, exec, readonly, umask, wait)
 - ❌ Job control features (bg, fg, jobs, &)
 
 ## Compliance Metrics
@@ -290,7 +289,7 @@ This document outlines the current progress toward full POSIX sh (IEEE Std 1003.
 
 - **Basic Execution**: 95% ✅
 - **Control Structures**: 95% ✅ (if/elif/else, case with glob patterns, for/while/until loops, functions with return, subshells, command grouping implemented)
-- **Built-in Commands**: 84% ✅ (26 built-ins implemented out of 31 POSIX required, including critical `set` builtin)
+- **Built-in Commands**: 87% ✅ (27 built-ins implemented out of 31 POSIX required, including critical `set` and `times` builtins)
 - **Expansions**: 98% ✅ (Parameter expansion with indirect expansion, arithmetic expansion, and brace expansion fully implemented)
 - **Redirections**: 95% ✅ (Full I/O redirection, here-documents, here-strings, and file descriptor operations implemented)
 - **Job Control**: 0% ❌ (optional POSIX feature)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -231,7 +231,7 @@
                                         </div>
                                         <div class="component-content">
                                             <ul>
-                                                <li>26 built-in commands</li>
+                                                <li>27 built-in commands</li>
                                                 <li>Optimized execution</li>
                                                 <li>No process spawning</li>
                                                 <li>Direct state access</li>

--- a/docs/compliance.html
+++ b/docs/compliance.html
@@ -120,7 +120,7 @@
                                 <div class="stat-label">Overall Compliance</div>
                             </div>
                             <div class="stat-item">
-                                <div class="stat-number">26</div>
+                                <div class="stat-number">27</div>
                                 <div class="stat-label">Built-in Commands</div>
                             </div>
                             <div class="stat-item">
@@ -471,8 +471,8 @@
                         <div class="status-summary">
                             <h3>Implementation Status</h3>
                             <div class="status-badges">
-                                <span class="badge implemented">26 Implemented</span>
-                                <span class="badge missing">6 Missing</span>
+                                <span class="badge implemented">27 Implemented</span>
+                                <span class="badge missing">5 Missing</span>
                             </div>
                         </div>
 
@@ -524,8 +524,8 @@
                                         <span class="status-icon">✅</span>
                                         <span class="item-text">shift</span>
                                     </div>
-                                    <div class="compliance-item missing">
-                                        <span class="status-icon">❌</span>
+                                    <div class="compliance-item implemented">
+                                        <span class="status-icon">✅</span>
                                         <span class="item-text">times</span>
                                     </div>
                                     <div class="compliance-item implemented">
@@ -548,7 +548,7 @@
                             </div>
 
                             <div class="builtins-column">
-                                <h4>Currently Implemented (26)</h4>
+                                <h4>Currently Implemented (27)</h4>
                                 <div class="implemented-list">
                                     <div class="builtin-tag">: (colon)</div>
                                     <div class="builtin-tag">alias</div>
@@ -572,6 +572,7 @@
                                     <div class="builtin-tag">shift</div>
                                     <div class="builtin-tag">source</div>
                                     <div class="builtin-tag">test</div>
+                                    <div class="builtin-tag">times</div>
                                     <div class="builtin-tag">trap</div>
                                     <div class="builtin-tag">type</div>
                                     <div class="builtin-tag">unalias</div>
@@ -642,7 +643,7 @@
                                 <div class="test-label">Core Components Covered</div>
                             </div>
                             <div class="test-stat">
-                                <div class="test-number">26</div>
+                                <div class="test-number">27</div>
                                 <div class="test-label">Built-ins Tested</div>
                             </div>
                         </div>
@@ -760,7 +761,7 @@
                                 </div>
                                 <div class="breakdown-item">
                                     <span class="category">Built-in Commands</span>
-                                    <span class="percentage implemented">81%</span>
+                                    <span class="percentage implemented">87%</span>
                                 </div>
                                 <div class="breakdown-item">
                                     <span class="category">Expansions</span>

--- a/docs/features.html
+++ b/docs/features.html
@@ -589,7 +589,7 @@ local var="value"</code></pre>
                     <h2>🛠️ Built-in Commands</h2>
 
                     <div class="builtins-overview">
-                        <p>Rush includes <strong>26 comprehensive built-in commands</strong> for enhanced functionality
+                        <p>Rush includes <strong>27 comprehensive built-in commands</strong> for enhanced functionality
                             and performance:</p>
 
                         <div class="builtins-grid">

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,7 +122,7 @@
                                     <div class="stat-label">POSIX Compliant</div>
                                 </div>
                                 <div class="stat">
-                                    <div class="stat-value">26</div>
+                                    <div class="stat-value">27</div>
                                     <div class="stat-label">Built-in Commands</div>
                                 </div>
                                 <div class="stat">

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -60,6 +60,7 @@ mod builtin_set_condensed;
 mod builtin_shift;
 mod builtin_source;
 mod builtin_test;
+mod builtin_times;
 mod builtin_trap;
 mod builtin_type;
 mod builtin_unalias;
@@ -113,6 +114,7 @@ fn get_builtins() -> Vec<Box<dyn Builtin>> {
         Box::new(builtin_set_condensed::SetCondensedBuiltin),
         Box::new(builtin_shift::ShiftBuiltin),
         Box::new(builtin_declare::DeclareBuiltin),
+        Box::new(builtin_times::TimesBuiltin),
         Box::new(builtin_trap::TrapBuiltin),
         Box::new(builtin_type::TypeBuiltin),
         Box::new(builtin_return::ReturnBuiltin),
@@ -447,6 +449,7 @@ mod tests {
         assert!(commands.contains(&"continue".to_string()));
         assert!(commands.contains(&"set".to_string()));
         assert!(commands.contains(&":".to_string()));
-        assert_eq!(commands.len(), 28);
+        assert!(commands.contains(&"times".to_string()));
+        assert_eq!(commands.len(), 29);
     }
 }

--- a/src/builtins/builtin_times.rs
+++ b/src/builtins/builtin_times.rs
@@ -31,8 +31,8 @@ impl super::Builtin for TimesBuiltin {
         }
 
         // Get resource usage for the shell process and its children
-        let (shell_user, shell_sys) = get_rusage_self();
-        let (children_user, children_sys) = get_rusage_children();
+        let (shell_user, shell_sys) = get_rusage(libc::RUSAGE_SELF);
+        let (children_user, children_sys) = get_rusage(libc::RUSAGE_CHILDREN);
 
         // Format and output the times
         // Format: XmY.ZZs (e.g., 0m0.12s)
@@ -53,36 +53,15 @@ impl super::Builtin for TimesBuiltin {
     }
 }
 
-/// Get resource usage for the current process (RUSAGE_SELF)
-fn get_rusage_self() -> (f64, f64) {
+/// Get resource usage for either the current process or its children
+fn get_rusage(usage_type: i32) -> (f64, f64) {
     #[cfg(unix)]
     {
         use std::mem::MaybeUninit;
-        
-        unsafe {
-            let mut usage = MaybeUninit::<libc::rusage>::uninit();
-            if libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) == 0 {
-                let usage = usage.assume_init();
-                let user_time = timeval_to_seconds(&usage.ru_utime);
-                let sys_time = timeval_to_seconds(&usage.ru_stime);
-                return (user_time, sys_time);
-            }
-        }
-    }
-    
-    // Fallback for non-Unix systems or if getrusage fails
-    (0.0, 0.0)
-}
 
-/// Get resource usage for child processes (RUSAGE_CHILDREN)
-fn get_rusage_children() -> (f64, f64) {
-    #[cfg(unix)]
-    {
-        use std::mem::MaybeUninit;
-        
         unsafe {
             let mut usage = MaybeUninit::<libc::rusage>::uninit();
-            if libc::getrusage(libc::RUSAGE_CHILDREN, usage.as_mut_ptr()) == 0 {
+            if libc::getrusage(usage_type, usage.as_mut_ptr()) == 0 {
                 let usage = usage.assume_init();
                 let user_time = timeval_to_seconds(&usage.ru_utime);
                 let sys_time = timeval_to_seconds(&usage.ru_stime);
@@ -90,7 +69,7 @@ fn get_rusage_children() -> (f64, f64) {
             }
         }
     }
-    
+
     // Fallback for non-Unix systems or if getrusage fails
     (0.0, 0.0)
 }

--- a/src/builtins/builtin_times.rs
+++ b/src/builtins/builtin_times.rs
@@ -1,0 +1,253 @@
+use std::io::Write;
+
+use crate::parser::ShellCommand;
+use crate::state::ShellState;
+
+pub struct TimesBuiltin;
+
+impl super::Builtin for TimesBuiltin {
+    fn name(&self) -> &'static str {
+        "times"
+    }
+
+    fn names(&self) -> Vec<&'static str> {
+        vec![self.name()]
+    }
+
+    fn description(&self) -> &'static str {
+        "Display accumulated user and system CPU times for the shell and its child processes"
+    }
+
+    fn run(
+        &self,
+        cmd: &ShellCommand,
+        _shell_state: &mut ShellState,
+        output_writer: &mut dyn Write,
+    ) -> i32 {
+        // POSIX times takes no arguments
+        if cmd.args.len() > 1 {
+            let _ = writeln!(output_writer, "times: too many arguments");
+            return 1;
+        }
+
+        // Get resource usage for the shell process and its children
+        let (shell_user, shell_sys) = get_rusage_self();
+        let (children_user, children_sys) = get_rusage_children();
+
+        // Format and output the times
+        // Format: XmY.ZZs (e.g., 0m0.12s)
+        let _ = writeln!(
+            output_writer,
+            "{} {}",
+            format_time(shell_user),
+            format_time(shell_sys)
+        );
+        let _ = writeln!(
+            output_writer,
+            "{} {}",
+            format_time(children_user),
+            format_time(children_sys)
+        );
+
+        0
+    }
+}
+
+/// Get resource usage for the current process (RUSAGE_SELF)
+fn get_rusage_self() -> (f64, f64) {
+    #[cfg(unix)]
+    {
+        use std::mem::MaybeUninit;
+        
+        unsafe {
+            let mut usage = MaybeUninit::<libc::rusage>::uninit();
+            if libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) == 0 {
+                let usage = usage.assume_init();
+                let user_time = timeval_to_seconds(&usage.ru_utime);
+                let sys_time = timeval_to_seconds(&usage.ru_stime);
+                return (user_time, sys_time);
+            }
+        }
+    }
+    
+    // Fallback for non-Unix systems or if getrusage fails
+    (0.0, 0.0)
+}
+
+/// Get resource usage for child processes (RUSAGE_CHILDREN)
+fn get_rusage_children() -> (f64, f64) {
+    #[cfg(unix)]
+    {
+        use std::mem::MaybeUninit;
+        
+        unsafe {
+            let mut usage = MaybeUninit::<libc::rusage>::uninit();
+            if libc::getrusage(libc::RUSAGE_CHILDREN, usage.as_mut_ptr()) == 0 {
+                let usage = usage.assume_init();
+                let user_time = timeval_to_seconds(&usage.ru_utime);
+                let sys_time = timeval_to_seconds(&usage.ru_stime);
+                return (user_time, sys_time);
+            }
+        }
+    }
+    
+    // Fallback for non-Unix systems or if getrusage fails
+    (0.0, 0.0)
+}
+
+/// Convert a timeval struct to seconds as a floating-point number
+#[cfg(unix)]
+fn timeval_to_seconds(tv: &libc::timeval) -> f64 {
+    tv.tv_sec as f64 + (tv.tv_usec as f64 / 1_000_000.0)
+}
+
+/// Format time in the POSIX format: XmY.ZZs
+/// Examples: 0m0.12s, 1m23.45s, 10m5.67s
+fn format_time(seconds: f64) -> String {
+    let minutes = (seconds as i64) / 60;
+    let remaining_seconds = seconds - (minutes as f64 * 60.0);
+    format!("{}m{:.2}s", minutes, remaining_seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtins::Builtin;
+
+    #[test]
+    fn test_times_builtin_basic_execution() {
+        let cmd = ShellCommand {
+            args: vec!["times".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = TimesBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        
+        assert_eq!(exit_code, 0);
+        
+        let output_str = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = output_str.trim().split('\n').collect();
+        
+        // Should have exactly 2 lines
+        assert_eq!(lines.len(), 2, "times output should have exactly 2 lines");
+        
+        // Each line should have 2 time values
+        for line in lines {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            assert_eq!(parts.len(), 2, "each line should have 2 time values");
+            
+            // Each time value should match the format XmY.ZZs
+            for part in parts {
+                assert!(part.contains('m'), "time should contain 'm'");
+                assert!(part.ends_with('s'), "time should end with 's'");
+            }
+        }
+    }
+
+    #[test]
+    fn test_times_builtin_no_arguments() {
+        let cmd = ShellCommand {
+            args: vec!["times".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = TimesBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        
+        assert_eq!(exit_code, 0);
+    }
+
+    #[test]
+    fn test_times_builtin_rejects_arguments() {
+        let cmd = ShellCommand {
+            args: vec!["times".to_string(), "arg1".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = TimesBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        
+        assert_eq!(exit_code, 1);
+        
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("too many arguments"));
+    }
+
+    #[test]
+    fn test_format_time() {
+        // Test various time values
+        assert_eq!(format_time(0.0), "0m0.00s");
+        assert_eq!(format_time(0.12), "0m0.12s");
+        assert_eq!(format_time(1.5), "0m1.50s");
+        assert_eq!(format_time(59.99), "0m59.99s");
+        assert_eq!(format_time(60.0), "1m0.00s");
+        assert_eq!(format_time(83.45), "1m23.45s");
+        assert_eq!(format_time(605.67), "10m5.67s");
+        assert_eq!(format_time(3661.89), "61m1.89s");
+    }
+
+    #[test]
+    fn test_times_output_format() {
+        let cmd = ShellCommand {
+            args: vec!["times".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+        let mut shell_state = ShellState::new();
+        let builtin = TimesBuiltin;
+        let mut output = Vec::new();
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+        
+        assert_eq!(exit_code, 0);
+        
+        let output_str = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = output_str.trim().split('\n').collect();
+        
+        // Verify format of first line (shell times)
+        let shell_times: Vec<&str> = lines[0].split_whitespace().collect();
+        assert_eq!(shell_times.len(), 2);
+        
+        // Verify format of second line (children times)
+        let children_times: Vec<&str> = lines[1].split_whitespace().collect();
+        assert_eq!(children_times.len(), 2);
+        
+        // Verify all times match the pattern XmY.ZZs
+        for time_str in shell_times.iter().chain(children_times.iter()) {
+            // Should have format like "0m0.12s"
+            let m_pos = time_str.find('m').expect("should contain 'm'");
+            let s_pos = time_str.find('s').expect("should contain 's'");
+            
+            assert!(m_pos < s_pos, "m should come before s");
+            assert!(s_pos == time_str.len() - 1, "s should be at the end");
+            
+            // Extract the seconds part and verify it has 2 decimal places
+            let seconds_part = &time_str[m_pos + 1..s_pos];
+            assert!(seconds_part.contains('.'), "seconds should have decimal point");
+            
+            let decimal_pos = seconds_part.find('.').unwrap();
+            let decimal_places = seconds_part.len() - decimal_pos - 1;
+            assert_eq!(decimal_places, 2, "should have exactly 2 decimal places");
+        }
+    }
+
+    #[test]
+    fn test_times_builtin_name() {
+        let builtin = TimesBuiltin;
+        assert_eq!(builtin.name(), "times");
+        assert_eq!(builtin.names(), vec!["times"]);
+    }
+
+    #[test]
+    fn test_times_builtin_description() {
+        let builtin = TimesBuiltin;
+        assert!(!builtin.description().is_empty());
+        assert!(builtin.description().contains("CPU"));
+    }
+}

--- a/src/builtins/builtin_times.rs
+++ b/src/builtins/builtin_times.rs
@@ -26,7 +26,7 @@ impl super::Builtin for TimesBuiltin {
     ) -> i32 {
         // POSIX times takes no arguments
         if cmd.args.len() > 1 {
-            let _ = writeln!(output_writer, "times: too many arguments");
+            eprintln!("times: too many arguments");
             return 1;
         }
 

--- a/src/builtins/builtin_times.rs
+++ b/src/builtins/builtin_times.rs
@@ -176,8 +176,7 @@ mod tests {
         
         assert_eq!(exit_code, 1);
         
-        let output_str = String::from_utf8(output).unwrap();
-        assert!(output_str.contains("too many arguments"));
+        assert!(output.is_empty(), "no output should be written to stdout on error");
     }
 
     #[test]


### PR DESCRIPTION
Implements the POSIX-required times built-in command (IEEE Std 1003.1-2008, Section 2.14) to display accumulated user and system CPU times for the shell and its child processes.

## Changes

- **New builtin:** `src/builtins/builtin_times.rs`
  - Uses `libc::getrusage()` with `RUSAGE_SELF` and `RUSAGE_CHILDREN`
  - POSIX-compliant output format: `XmY.ZZs` (e.g., `0m0.12s`)
  - Displays 4 time values on 2 lines (shell user/system, children user/system)
  - Rejects arguments per POSIX specification
  - 7 comprehensive test cases

## Testing

All 574 tests pass, including 7 new tests for the `times` builtin covering:

- Basic execution and output format validation
- Argument rejection
- Exit code verification
- Time formatting accuracy

## Compliance Impact

Improves POSIX compliance by implementing another required special built-in utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new built-in command to display accumulated CPU time metrics for the shell and its child processes.

* **Documentation**
  * Updated docs and site copy to reflect the new built-in and improved POSIX compliance (built-ins implemented: 27; compliance ~87%).

* **Tests**
  * Test coverage and validation updated to include the new built-in.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->