### PR TITLE
Fix kill builtin to support negative PIDs via -- separator and -s/-n options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "glob",
  "lazy_static",
  "libc",
+ "rush-sh",
  "rustyline",
  "signal-hook 0.4.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ glob = "0.3.3"
 clap = { version = "4.5.54", features = ["derive"] }
 lazy_static = "1.5.0"
 libc = "0.2.180"
+
+[dev-dependencies]
+rush-sh = { path = "." }

--- a/src/builtins/builtin_bg.rs
+++ b/src/builtins/builtin_bg.rs
@@ -140,14 +140,13 @@ impl Builtin for BgBuiltin {
 mod tests {
     use super::*;
     use crate::state::Job;
-    use std::sync::Mutex;
-
-    // Mutex to serialize tests that modify environment variables
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    
+    #[cfg(test)]
+    use rush_sh::test_sync::JOB_CONTROL_LOCK;
 
     #[test]
     fn test_bg_no_jobs() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -167,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_bg_invalid_jobspec() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job
@@ -191,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_bg_completed_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a completed job
@@ -216,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_bg_already_running_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a running job
@@ -242,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_bg_stopped_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job
@@ -273,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_bg_current_jobspec() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job as current
@@ -299,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_bg_previous_jobspec() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add two jobs
@@ -327,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_current_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -347,7 +346,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_previous_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add only one job (no previous)
@@ -371,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_bg_direct_number_jobspec() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job
@@ -397,7 +396,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_prefix_match() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add jobs with different commands
@@ -425,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_contains_match() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add jobs with different commands
@@ -453,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_bg_multiple_jobspecs() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add multiple stopped jobs
@@ -494,7 +493,7 @@ mod tests {
 
     #[test]
     fn test_bg_multiple_jobspecs_with_invalid() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add one stopped job
@@ -523,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_bg_pipeline_with_multiple_pids() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped pipeline with multiple PIDs
@@ -559,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_arguments_uses_current_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job as current
@@ -589,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_bg_mixed_jobspec_formats() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add multiple stopped jobs
@@ -629,7 +628,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_prefix_skips_completed_jobs() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         
         // Add a completed job with "sleep" command
@@ -650,7 +649,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_contains_skips_completed_jobs() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         
         // Add a completed job containing "pattern"

--- a/src/builtins/builtin_bg.rs
+++ b/src/builtins/builtin_bg.rs
@@ -140,9 +140,14 @@ impl Builtin for BgBuiltin {
 mod tests {
     use super::*;
     use crate::state::Job;
+    use std::sync::Mutex;
+
+    // Mutex to serialize tests that modify environment variables
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_bg_no_jobs() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -162,6 +167,7 @@ mod tests {
 
     #[test]
     fn test_bg_invalid_jobspec() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job
@@ -185,6 +191,7 @@ mod tests {
 
     #[test]
     fn test_bg_completed_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a completed job
@@ -209,6 +216,7 @@ mod tests {
 
     #[test]
     fn test_bg_already_running_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a running job
@@ -234,6 +242,7 @@ mod tests {
 
     #[test]
     fn test_bg_stopped_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job
@@ -264,6 +273,7 @@ mod tests {
 
     #[test]
     fn test_bg_current_jobspec() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job as current
@@ -289,6 +299,7 @@ mod tests {
 
     #[test]
     fn test_bg_previous_jobspec() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add two jobs
@@ -316,6 +327,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_current_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -335,6 +347,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_previous_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add only one job (no previous)
@@ -358,6 +371,7 @@ mod tests {
 
     #[test]
     fn test_bg_direct_number_jobspec() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job
@@ -383,6 +397,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_prefix_match() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add jobs with different commands
@@ -410,6 +425,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_contains_match() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add jobs with different commands
@@ -437,6 +453,7 @@ mod tests {
 
     #[test]
     fn test_bg_multiple_jobspecs() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add multiple stopped jobs
@@ -477,6 +494,7 @@ mod tests {
 
     #[test]
     fn test_bg_multiple_jobspecs_with_invalid() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add one stopped job
@@ -505,6 +523,7 @@ mod tests {
 
     #[test]
     fn test_bg_pipeline_with_multiple_pids() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped pipeline with multiple PIDs
@@ -540,6 +559,7 @@ mod tests {
 
     #[test]
     fn test_bg_no_arguments_uses_current_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a stopped job as current
@@ -569,6 +589,7 @@ mod tests {
 
     #[test]
     fn test_bg_mixed_jobspec_formats() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add multiple stopped jobs
@@ -608,6 +629,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_prefix_skips_completed_jobs() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         
         // Add a completed job with "sleep" command
@@ -628,6 +650,7 @@ mod tests {
 
     #[test]
     fn test_bg_command_contains_skips_completed_jobs() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         
         // Add a completed job containing "pattern"

--- a/src/builtins/builtin_kill.rs
+++ b/src/builtins/builtin_kill.rs
@@ -309,14 +309,13 @@ impl Builtin for KillBuiltin {
 mod tests {
     use super::*;
     use crate::state::Job;
-    use std::sync::Mutex;
-
-    // Mutex to serialize tests that modify environment variables
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    
+    #[cfg(test)]
+    use rush_sh::test_sync::JOB_CONTROL_LOCK;
 
     #[test]
     fn test_kill_no_arguments() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -336,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_kill_list_signals() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -386,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_signal_name() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -407,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_kill_invalid_pid() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -427,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_kill_jobspec_no_jobs() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -447,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_kill_jobspec_current() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job with the current process PID (so we can test without actually killing)
@@ -471,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_kill_multiple_targets() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -493,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_dash_signal() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -515,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_dash_number() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -535,7 +534,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_n_option() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -555,7 +554,7 @@ mod tests {
 
     #[test]
     fn test_kill_missing_signal_argument() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -575,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_kill_no_targets_after_signal() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -595,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_current() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -609,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_previous() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job1 = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         let job2 = Job::new(2, Some(1235), "sleep 20 &".to_string(), vec![1235], false);
@@ -622,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_number() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(5, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -633,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_prefix() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -644,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_contains() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "grep pattern file &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -655,7 +654,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_for_job() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234, 1235], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -670,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_for_pid() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         let result = KillBuiltin::get_target_pids("1234", &shell_state);
@@ -682,7 +681,7 @@ mod tests {
 
     #[test]
     fn test_kill_job_with_multiple_pids() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job with multiple PIDs (use invalid PIDs so we don't actually kill anything)
@@ -707,7 +706,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_negative_pid() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test negative PID (process group)
@@ -720,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_zero() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test PID 0 (current process group)
@@ -733,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_minus_one() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test PID -1 (all processes)
@@ -746,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_positive_pid() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test positive PID (single process)
@@ -782,7 +781,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_process_group() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -805,7 +804,7 @@ mod tests {
 
     #[test]
     fn test_kill_zero_current_process_group() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -825,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_kill_minus_one_all_processes() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -854,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_kill_multiple_negative_pids() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -878,7 +877,7 @@ mod tests {
 
     #[test]
     fn test_kill_mixed_positive_and_negative_pids() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -900,7 +899,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_preserves_sign_for_large_negative() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test large negative PID
@@ -913,7 +912,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_separator() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -935,7 +934,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_with_default_signal() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -957,7 +956,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_without_double_dash() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -980,7 +979,7 @@ mod tests {
 
     #[test]
     fn test_kill_ambiguous_negative_number_as_signal() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -1002,7 +1001,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_after_explicit_signal() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -1024,7 +1023,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_multiple_negative_pids() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -1046,7 +1045,7 @@ mod tests {
 
     #[test]
     fn test_kill_invalid_signal_with_negative_number() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = JOB_CONTROL_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 

--- a/src/builtins/builtin_kill.rs
+++ b/src/builtins/builtin_kill.rs
@@ -201,12 +201,17 @@ impl Builtin for KillBuiltin {
         let mut signal = libc::SIGTERM; // Default signal
         let mut arg_index = 1;
         let mut targets = Vec::new();
+        let mut signal_specified_with_option = false; // Track if signal was specified with -s or -n
 
         // Parse options and signal specification
         while arg_index < args.len() {
             let arg = &args[arg_index];
 
-            if arg == "-l" {
+            if arg == "--" {
+                // End of options marker - remaining arguments are targets
+                arg_index += 1;
+                break;
+            } else if arg == "-l" {
                 // List signals
                 return Self::list_signals(output_writer);
             } else if arg == "-s" {
@@ -217,7 +222,10 @@ impl Builtin for KillBuiltin {
                     return 1;
                 }
                 match Self::parse_signal(&args[arg_index]) {
-                    Ok(sig) => signal = sig,
+                    Ok(sig) => {
+                        signal = sig;
+                        signal_specified_with_option = true;
+                    }
                     Err(e) => {
                         let _ = writeln!(output_writer, "{}", e);
                         return 1;
@@ -232,15 +240,18 @@ impl Builtin for KillBuiltin {
                     return 1;
                 }
                 match args[arg_index].parse::<i32>() {
-                    Ok(num) if num >= 0 => signal = num,
+                    Ok(num) if num >= 0 => {
+                        signal = num;
+                        signal_specified_with_option = true;
+                    }
                     _ => {
                         let _ = writeln!(output_writer, "kill: {}: invalid signal specification", args[arg_index]);
                         return 1;
                     }
                 }
                 arg_index += 1;
-            } else if arg.starts_with('-') && arg.len() > 1 {
-                // Signal specified with -SIGNAME or -NUM format
+            } else if !signal_specified_with_option && arg.starts_with('-') && arg.len() > 1 {
+                // Signal specified with -SIGNAME or -NUM format (only if not already specified with -s/-n)
                 let sig_spec = &arg[1..];
                 match Self::parse_signal(sig_spec) {
                     Ok(sig) => signal = sig,
@@ -738,13 +749,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // IGNORED: Command-line parsing issue prevents negative PIDs from working properly
-    // The kill builtin cannot handle negative PIDs as arguments because they are interpreted
-    // as signal specifications (e.g., -999999 is parsed as signal 999999, not PID -999999).
-    // This test is kept but ignored until the command-line parsing is refactored to support
-    // the `--` separator or special handling for negative numbers. See TODO.md for details.
     #[test]
-    #[ignore]
     fn test_kill_negative_pid_process_group() {
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
@@ -813,10 +818,7 @@ mod tests {
         assert_eq!(result.unwrap(), 0);
     }
 
-    // IGNORED: Command-line parsing issue prevents negative PIDs from working properly
-    // See comment on test_kill_negative_pid_process_group above and TODO.md for details.
     #[test]
-    #[ignore]
     fn test_kill_multiple_negative_pids() {
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
@@ -844,9 +846,9 @@ mod tests {
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
-        // Mix of positive PID and negative PID (process group)
+        // Mix of positive PID and negative PID (process group) - use -- for negative PID
         let cmd = ShellCommand {
-            args: vec!["kill".to_string(), "999998".to_string(), "-999999".to_string()],
+            args: vec!["kill".to_string(), "999998".to_string(), "--".to_string(), "-999999".to_string()],
             redirections: Vec::new(),
             compound: None,
         };
@@ -870,5 +872,152 @@ mod tests {
         let pids = result.unwrap();
         assert_eq!(pids.len(), 1);
         assert_eq!(pids[0], -32768);
+    }
+
+    #[test]
+    fn test_kill_double_dash_separator() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // Use -- to separate options from arguments
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "-s".to_string(), "TERM".to_string(), "--".to_string(), "-999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail because process group doesn't exist
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("No such process group") || output_str.contains("999999"));
+    }
+
+    #[test]
+    fn test_kill_double_dash_with_default_signal() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // Use -- with default signal (TERM)
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "--".to_string(), "-999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail because process group doesn't exist
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("No such process group") || output_str.contains("999999"));
+    }
+
+    #[test]
+    fn test_kill_negative_pid_without_double_dash() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // Without --, negative numbers are treated as signal specifications
+        // -999999 is not a valid signal, so it should fail with invalid signal error
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "-999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail with invalid signal specification
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("invalid signal specification") || output_str.contains("usage"));
+    }
+
+    #[test]
+    fn test_kill_ambiguous_negative_number_as_signal() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // -9 should be interpreted as signal 9 (SIGKILL), not PID -9
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "-9".to_string(), "999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail because PID doesn't exist
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("No such process") || output_str.contains("999999"));
+    }
+
+    #[test]
+    fn test_kill_negative_pid_after_explicit_signal() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // After explicit signal with -s, negative numbers should be PIDs
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "-s".to_string(), "TERM".to_string(), "-999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail because process group doesn't exist
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("No such process group") || output_str.contains("999999"));
+    }
+
+    #[test]
+    fn test_kill_double_dash_multiple_negative_pids() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // Multiple negative PIDs after --
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "--".to_string(), "-999998".to_string(), "-999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        // Should fail for both process groups
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("process group") || output_str.contains("999998") || output_str.contains("999999"));
+    }
+
+    #[test]
+    fn test_kill_invalid_signal_with_negative_number() {
+        let mut shell_state = ShellState::new();
+        let mut output = Vec::new();
+
+        // -INVALID should fail as invalid signal, not be treated as negative PID
+        let cmd = ShellCommand {
+            args: vec!["kill".to_string(), "-INVALID".to_string(), "999999".to_string()],
+            redirections: Vec::new(),
+            compound: None,
+        };
+
+        let builtin = KillBuiltin;
+        let exit_code = builtin.run(&cmd, &mut shell_state, &mut output);
+
+        assert_eq!(exit_code, 1);
+        let output_str = String::from_utf8(output).unwrap();
+        assert!(output_str.contains("invalid signal specification"));
     }
 }

--- a/src/builtins/builtin_kill.rs
+++ b/src/builtins/builtin_kill.rs
@@ -254,7 +254,10 @@ impl Builtin for KillBuiltin {
                 // Signal specified with -SIGNAME or -NUM format (only if not already specified with -s/-n)
                 let sig_spec = &arg[1..];
                 match Self::parse_signal(sig_spec) {
-                    Ok(sig) => signal = sig,
+                    Ok(sig) => {
+                        signal = sig;
+                        signal_specified_with_option = true;
+                    }
                     Err(e) => {
                         let _ = writeln!(output_writer, "{}", e);
                         return 1;
@@ -306,9 +309,14 @@ impl Builtin for KillBuiltin {
 mod tests {
     use super::*;
     use crate::state::Job;
+    use std::sync::Mutex;
+
+    // Mutex to serialize tests that modify environment variables
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_kill_no_arguments() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -328,6 +336,7 @@ mod tests {
 
     #[test]
     fn test_kill_list_signals() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -377,6 +386,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_signal_name() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -397,6 +407,7 @@ mod tests {
 
     #[test]
     fn test_kill_invalid_pid() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -416,6 +427,7 @@ mod tests {
 
     #[test]
     fn test_kill_jobspec_no_jobs() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -435,6 +447,7 @@ mod tests {
 
     #[test]
     fn test_kill_jobspec_current() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job with the current process PID (so we can test without actually killing)
@@ -458,6 +471,7 @@ mod tests {
 
     #[test]
     fn test_kill_multiple_targets() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -479,6 +493,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_dash_signal() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -500,6 +515,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_dash_number() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -519,6 +535,7 @@ mod tests {
 
     #[test]
     fn test_kill_with_n_option() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -538,6 +555,7 @@ mod tests {
 
     #[test]
     fn test_kill_missing_signal_argument() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -557,6 +575,7 @@ mod tests {
 
     #[test]
     fn test_kill_no_targets_after_signal() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -576,6 +595,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_current() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -589,6 +609,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_previous() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job1 = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         let job2 = Job::new(2, Some(1235), "sleep 20 &".to_string(), vec![1235], false);
@@ -601,6 +622,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_number() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(5, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -611,6 +633,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_prefix() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -621,6 +644,7 @@ mod tests {
 
     #[test]
     fn test_parse_jobspec_by_contains() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "grep pattern file &".to_string(), vec![1234], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -631,6 +655,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_for_job() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
         let job = Job::new(1, Some(1234), "sleep 10 &".to_string(), vec![1234, 1235], false);
         shell_state.job_table.borrow_mut().add_job(job);
@@ -645,6 +670,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_for_pid() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         let result = KillBuiltin::get_target_pids("1234", &shell_state);
@@ -656,6 +682,7 @@ mod tests {
 
     #[test]
     fn test_kill_job_with_multiple_pids() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         
         // Add a job with multiple PIDs (use invalid PIDs so we don't actually kill anything)
@@ -680,6 +707,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_negative_pid() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test negative PID (process group)
@@ -692,6 +720,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_zero() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test PID 0 (current process group)
@@ -704,6 +733,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_minus_one() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test PID -1 (all processes)
@@ -716,6 +746,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_positive_pid() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test positive PID (single process)
@@ -751,6 +782,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_process_group() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -773,6 +805,7 @@ mod tests {
 
     #[test]
     fn test_kill_zero_current_process_group() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -792,6 +825,7 @@ mod tests {
 
     #[test]
     fn test_kill_minus_one_all_processes() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -820,6 +854,7 @@ mod tests {
 
     #[test]
     fn test_kill_multiple_negative_pids() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -843,12 +878,13 @@ mod tests {
 
     #[test]
     fn test_kill_mixed_positive_and_negative_pids() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
         // Mix of positive PID and negative PID (process group) - use -- for negative PID
         let cmd = ShellCommand {
-            args: vec!["kill".to_string(), "999998".to_string(), "--".to_string(), "-999999".to_string()],
+            args: vec!["kill".to_string(), "--".to_string(), "999998".to_string(), "-999999".to_string()],
             redirections: Vec::new(),
             compound: None,
         };
@@ -864,6 +900,7 @@ mod tests {
 
     #[test]
     fn test_get_target_pids_preserves_sign_for_large_negative() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let shell_state = ShellState::new();
 
         // Test large negative PID
@@ -876,6 +913,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_separator() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -897,6 +935,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_with_default_signal() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -918,6 +957,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_without_double_dash() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -940,6 +980,7 @@ mod tests {
 
     #[test]
     fn test_kill_ambiguous_negative_number_as_signal() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -961,6 +1002,7 @@ mod tests {
 
     #[test]
     fn test_kill_negative_pid_after_explicit_signal() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -982,6 +1024,7 @@ mod tests {
 
     #[test]
     fn test_kill_double_dash_multiple_negative_pids() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 
@@ -1003,6 +1046,7 @@ mod tests {
 
     #[test]
     fn test_kill_invalid_signal_with_negative_number() {
+        let _lock = ENV_LOCK.lock().unwrap();
         let mut shell_state = ShellState::new();
         let mut output = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,21 @@ pub use executor::execute;
 pub use lexer::Token;
 pub use parser::{Ast, ShellCommand};
 pub use state::ShellState;
+
+// Global test synchronization mutexes
+// These are always available but only used in tests
+#[doc(hidden)]
+pub mod test_sync {
+    use std::sync::Mutex;
+    
+    /// Mutex to serialize tests that modify job control state
+    /// Job control tests MUST use this mutex to prevent race conditions
+    /// when accessing the global job table through ShellState
+    pub static JOB_CONTROL_LOCK: Mutex<()> = Mutex::new(());
+    
+    /// Mutex to serialize tests that modify environment variables
+    pub static ENV_LOCK: Mutex<()> = Mutex::new(());
+    
+    /// Mutex to serialize tests that change the current directory
+    pub static DIR_CHANGE_LOCK: Mutex<()> = Mutex::new(());
+}


### PR DESCRIPTION
- Add support for -- separator to terminate option parsing
- Track when signal is specified with -s/-n to allow negative PIDs
- Add 7 comprehensive tests for negative PID handling
- Maintain POSIX-compliant behavior matching bash

Fixes #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kill command parsing: supports "--" to end options and correctly distinguishes explicit -s/-n options from leading -SIGNAME/-NUM forms to avoid misinterpreting negative values.

* **Tests**
  * Expanded tests for option/target parsing, default signaling, negative PID/group cases, and error messages.
  * Serialized environment- and job-control-dependent tests for deterministic execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->